### PR TITLE
9.0 setlists form

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -1,7 +1,7 @@
 class SetlistsController < ApplicationController
   def new
     @setlist = Setlist.new
-    @setlist.setlistitems.build
+    50.times { @setlist.setlistitems.build }
   end
 
   def create
@@ -17,8 +17,9 @@ class SetlistsController < ApplicationController
   private
 
   def setlist_params
-    params.permit(setlistitems_attributes: [:song_title, :position, :is_encore, :is_song, :is_arranged, :_destroy]).merge(
-      user_id: current_user.id, event_id: params[:event_id]
-    )
+    params.require(:setlist).permit(
+      :event_id, 
+      setlistitems_attributes: [:song_title, :position, :is_encore, :is_song, :is_arranged, :_destroy]
+      ).merge(user_id: current_user.id, event_id: params[:event_id])
   end
 end

--- a/app/models/setlistitem.rb
+++ b/app/models/setlistitem.rb
@@ -5,5 +5,4 @@ class Setlistitem < ApplicationRecord
   validates :is_arranged, inclusion: { in: [true, false] }
   validates :is_encore, inclusion: { in: [true, false] }
   validates :song_title, presence: true
-  validates :position, presence: true
 end

--- a/app/views/setlists/_setlistitem_form.html.erb
+++ b/app/views/setlists/_setlistitem_form.html.erb
@@ -2,12 +2,7 @@
   <li>
     <div class="nested-form-wrapper border p-3 mb-3" data-new-record="<%= f.object.new_record? %>">
       <div>
-        <%= f.label :song_title %>
-        <%= f.text_field :song_title, class: "border" %>
-      </div>
-      <div>
-        <%= f.label :position %>
-        <%= f.text_field :position, class: "border" %>
+        <%= f.text_field :song_title, class: "input input-bordered w-full max-w-xs", placeholder: "楽曲名" %>
       </div>
       <div>
         <%= f.label :is_encore %>
@@ -23,11 +18,11 @@
       </div>
 
       <div>
-        <button type="button" data-action="nested-form#remove">Remove Setlistitem</button>
+      <button type="button" data-action="nested-form#add" class="btn btn-info">楽曲を追加</button>
       </div>
 
       <div>
-        <button type="button" data-action="nested-form#add">Add Setlistitem</button>
+        <button type="button" data-action="nested-form#remove" class="btn btn-active btn-ghost">この曲を削除</button>
       </div>
 
       <%= f.hidden_field :_destroy %>

--- a/app/views/setlists/_setlistitem_form.html.erb
+++ b/app/views/setlists/_setlistitem_form.html.erb
@@ -1,32 +1,36 @@
-<div class="nested-form-wrapper border p-3 mb-3" data-new-record="<%= f.object.new_record? %>">
-  <div>
-    <%= f.label :song_title %>
-    <%= f.text_field :song_title, class: "border" %>
-  </div>
-  <div>
-    <%= f.label :position %>
-    <%= f.text_field :position, class: "border" %>
-  </div>
-  <div>
-    <%= f.label :is_encore %>
-    <%= f.check_box :is_encore %>
-  </div>
-  <div>
-    <%= f.label :is_song %>
-    <%= f.check_box :is_song %>
-  </div>
-  <div>
-    <%= f.label :is_arranged %>
-    <%= f.check_box :is_arranged %>
-  </div>
+<ul data-controller="sortable" data-sortable-animation-value="150">
+  <li>
+    <div class="nested-form-wrapper border p-3 mb-3" data-new-record="<%= f.object.new_record? %>">
+      <div>
+        <%= f.label :song_title %>
+        <%= f.text_field :song_title, class: "border" %>
+      </div>
+      <div>
+        <%= f.label :position %>
+        <%= f.text_field :position, class: "border" %>
+      </div>
+      <div>
+        <%= f.label :is_encore %>
+        <%= f.check_box :is_encore %>
+      </div>
+      <div>
+        <%= f.label :is_song %>
+        <%= f.check_box :is_song %>
+      </div>
+      <div>
+        <%= f.label :is_arranged %>
+        <%= f.check_box :is_arranged %>
+      </div>
 
-  <div>
-    <button type="button" data-action="nested-form#remove">Remove Setlistitem</button>
-  </div>
+      <div>
+        <button type="button" data-action="nested-form#remove">Remove Setlistitem</button>
+      </div>
 
-  <div>
-    <button type="button" data-action="nested-form#add">Add Setlistitem</button>
-  </div>
+      <div>
+        <button type="button" data-action="nested-form#add">Add Setlistitem</button>
+      </div>
 
-  <%= f.hidden_field :_destroy %>
-</div>
+      <%= f.hidden_field :_destroy %>
+    </div>
+  </li>
+</ul>

--- a/app/views/setlists/new.html.erb
+++ b/app/views/setlists/new.html.erb
@@ -1,29 +1,22 @@
 <h1>Setlists new</h1>
 
-<%= form_with model: @setlist, url: event_setlist_path do |f| %>
+<%= form_with model: @setlist,data: { controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper' }, url: event_setlist_path do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
-  <%= f.fields_for :setlistitems do |i| %>
-    <div>
-      <%= i.label :song_title %>
-      <%= i.text_field :song_title, class: "border" %>
-    </div>
-    <div>
-      <%= i.label :position %>
-      <%= i.text_field :position, class: "border" %>
-    </div>
-    <div>
-      <%= i.label :is_encore %>
-      <%= i.check_box :is_encore %>
-    </div>
-    <div>
-      <%= i.label :is_song %>
-      <%= i.check_box :is_song %>
-    </div>
-    <div>
-      <%= i.label :is_arranged %>
-      <%= i.check_box :is_arranged %>
-    </div>
-  <% end %>
+
+  <template data-nested-form-target="template">
+    <%= f.fields_for :setlistitems, Setlistitem.new, child_index: 'NEW_RECORD' do |i| %>
+      <%= render "setlistitem_form", f: i %>
+    <% end %>
+  </template>
+
+  <%#= f.fields_for :setlistitems do |i| %>
+    <%#= render "setlistitem_form", f: i %>
+  <%# end %>
+
+  <!-- Inserted elements will be injected before that target. -->
+  <div data-nested-form-target="target"></div>
+
+  <button type="button" data-action="nested-form#add">Add Setlistitem</button>
 
   <%= f.submit "投稿", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/setlists/new.html.erb
+++ b/app/views/setlists/new.html.erb
@@ -16,7 +16,9 @@
   <!-- Inserted elements will be injected before that target. -->
   <div data-nested-form-target="target"></div>
 
-  <button type="button" data-action="nested-form#add">Add Setlistitem</button>
+  <button type="button" data-action="nested-form#add" class="btn btn-info">楽曲を追加</button>
 
-  <%= f.submit "投稿", class: "btn btn-primary" %>
+  <div>
+    <%= f.submit "セットリストを投稿", class: "btn btn-primary" %>
+  </div>
 <% end %>

--- a/db/migrate/20241102015705_remove_position_from_setlistitems.rb
+++ b/db/migrate/20241102015705_remove_position_from_setlistitems.rb
@@ -1,0 +1,5 @@
+class RemovePositionFromSetlistitems < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :setlistitems, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_30_060252) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_02_015705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,7 +63,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_30_060252) do
   create_table "setlistitems", force: :cascade do |t|
     t.integer "song_id"
     t.text "song_title", null: false
-    t.integer "position", null: false
     t.boolean "is_encore", default: false, null: false
     t.boolean "is_song", default: true, null: false
     t.boolean "is_arranged", default: false, null: false


### PR DESCRIPTION
## 概要
セットリスト登録フォームを作成しました。
## 加えた変更
* 一つのsetlistに対して、最大50個のsetlistitemsを登録できるようにしました。
* setlistitemsからpositionカラムを削除しました。セットリストの表示はidをもとに順番を特定します。

## 加えなかった変更
* fes等でのリハーサルかどうかのボタン設置。
→後日対応します。
* #55 の権限関連等の設定
→後日対応します。

## 影響範囲

## 関連Issue
* close #56
