### PR TITLE
9.1 setlists autocomplite

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -14,6 +14,13 @@ class SetlistsController < ApplicationController
     end
   end
 
+  def search
+    @songs = Song.where("name_kana_ruby like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def setlist_params

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,6 +1,6 @@
 import { Application } from '@hotwired/stimulus'
-import RailsNestedForm from '@stimulus-components/rails-nested-form'
 import { Autocomplete } from 'stimulus-autocomplete'
+import RailsNestedForm from '@stimulus-components/rails-nested-form'
 
 const application = Application.start()
 application.register('nested-form', RailsNestedForm)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,5 +1,7 @@
 import { Application } from '@hotwired/stimulus'
 import RailsNestedForm from '@stimulus-components/rails-nested-form'
+import { Autocomplete } from 'stimulus-autocomplete'
 
 const application = Application.start()
 application.register('nested-form', RailsNestedForm)
+application.register('autocomplete', Autocomplete)

--- a/app/views/setlists/_setlistitem_form.html.erb
+++ b/app/views/setlists/_setlistitem_form.html.erb
@@ -1,8 +1,10 @@
 <ul data-controller="sortable" data-sortable-animation-value="150">
   <li>
     <div class="nested-form-wrapper border p-3 mb-3" data-new-record="<%= f.object.new_record? %>">
-      <div>
-        <%= f.text_field :song_title, class: "input input-bordered w-full max-w-xs", placeholder: "楽曲名" %>
+      <div data-controller="autocomplete" data-autocomplete-url-value="/setlists/search" role="combobox">
+        <%= f.text_field :song_title, class: "input input-bordered w-full max-w-xs", placeholder: "楽曲名", data: { autocomplete_target: 'input' } %>
+        <%= f.hidden_field :song_title, data: { autocomplete_target: 'hidden' } %>
+        <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
       </div>
       <div>
         <%= f.label :is_encore %>

--- a/app/views/setlists/new.html.erb
+++ b/app/views/setlists/new.html.erb
@@ -9,10 +9,6 @@
     <% end %>
   </template>
 
-  <%#= f.fields_for :setlistitems do |i| %>
-    <%#= render "setlistitem_form", f: i %>
-  <%# end %>
-
   <!-- Inserted elements will be injected before that target. -->
   <div data-nested-form-target="target"></div>
 

--- a/app/views/setlists/search.html.erb
+++ b/app/views/setlists/search.html.erb
@@ -1,0 +1,5 @@
+<% @songs.each do |song| %>
+  <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= song.id %>" data-autocomplete-label="<%= song.name %>">
+    <%= song.name %>
+  </li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,14 @@ Rails.application.routes.draw do
   resources :songs, only: [:index, :show] do
     resources :song_informations, only: [:create, :destroy], shallow: true
   end
+
   resources :events, only: [:index, :show] do
     resource :setlist, only: [:new, :create]
+  end
+
+  # セットリストのオートコンプリートのためのルーティング
+  resources :setlists do
+    get :search, on: :collection
   end
 
   get "up" => "rails/health#show", as: :rails_health_check

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "autoprefixer": "^10.4.20",
     "daisyui": "^4.12.13",
     "postcss": "^8.4.47",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^3.4.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,6 +838,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
## 概要
セットリスト登録フォームで曲名を途中まで入れると候補が表示されるようにしました。
## 加えた変更
* stimulus-autocompleteのインストール
* フォームに入力されたカタカナの文字列と一致する曲名を一覧表示

## 加えなかった変更
* カタカナ以外の文字列への対応
→後日実施します

## 影響範囲

## 関連Issue
* #57 
