### PR TITLE
feat: セトリ登録時の楽曲id紐付け

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -6,7 +6,10 @@ class SetlistsController < ApplicationController
 
   def create
     @setlist = Setlist.new(setlist_params)
-    # binding.pry
+    @setlist.setlistitems.each do |item|
+      item.set_song_id
+    end
+
     if @setlist.save
       redirect_to events_path
     else

--- a/app/models/setlistitem.rb
+++ b/app/models/setlistitem.rb
@@ -5,4 +5,11 @@ class Setlistitem < ApplicationRecord
   validates :is_arranged, inclusion: { in: [true, false] }
   validates :is_encore, inclusion: { in: [true, false] }
   validates :song_title, presence: true
+
+  def set_song_id
+    @song = Song.find_by(name: "#{self.song_title}")
+    if @song
+      self.song_id = @song.id
+    end
+  end
 end


### PR DESCRIPTION
## 概要
セトリ登録時にsong_idが入るようにしました。
## 加えた変更
* Setlistの`create`アクション時に、各setlistitemに対して`set_song_id`メソッドを実行され`song_id`カラムが自動で入力される。

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #58 
