### PR TITLE
9.5 setlistitems information

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,5 +9,8 @@ class EventsController < ApplicationController
     return unless @event.setlist
 
     @setlistitems = Setlistitem.where(setlist_id: @event.setlist.id)
+    @setlistitems.each do |item|
+      item.set_information
+    end
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,8 +9,6 @@ class EventsController < ApplicationController
     return unless @event.setlist
 
     @setlistitems = Setlistitem.where(setlist_id: @event.setlist.id)
-    @setlistitems.each do |item|
-      item.set_info
-    end
+    @setlistitems.each(&:set_info)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,7 +10,7 @@ class EventsController < ApplicationController
 
     @setlistitems = Setlistitem.where(setlist_id: @event.setlist.id)
     @setlistitems.each do |item|
-      item.set_information
+      item.set_info
     end
   end
 end

--- a/app/controllers/setlistitem_informations_controller.rb
+++ b/app/controllers/setlistitem_informations_controller.rb
@@ -1,0 +1,16 @@
+class SetlistitemInformationsController < ApplicationController
+  def create
+    @new_info = SetlistitemInformation.new(setlistitem_information_params)
+    if @new_info.save
+      redirect_to events_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def setlistitem_information_params
+    params.require(:setlistitem_information).permit(:body, :setlistitem_id).merge(user_id: current_user.id)
+  end
+end

--- a/app/helpers/setlistitem_informations_helper.rb
+++ b/app/helpers/setlistitem_informations_helper.rb
@@ -1,0 +1,2 @@
+module SetlistitemInformationsHelper
+end

--- a/app/models/setlistitem.rb
+++ b/app/models/setlistitem.rb
@@ -15,7 +15,6 @@ class Setlistitem < ApplicationRecord
   end
 
   def set_info
-    @new_info = SetlistitemInformation.new
     @infos = SetlistitemInformation.where(setlistitem_id: self.id)
   end
 end

--- a/app/models/setlistitem.rb
+++ b/app/models/setlistitem.rb
@@ -14,6 +14,8 @@ class Setlistitem < ApplicationRecord
     self.song_id = @song.id
   end
 
-  def set_information
+  def set_info
+    @new_info = SetlistitemInformation.new
+    @infos = SetlistitemInformation.where(setlistitem_id: self.id)
   end
 end

--- a/app/models/setlistitem.rb
+++ b/app/models/setlistitem.rb
@@ -1,5 +1,6 @@
 class Setlistitem < ApplicationRecord
   belongs_to :setlist
+  has_many :setlistitem_informations, dependent: :destroy
 
   validates :is_song, inclusion: { in: [true, false] }
   validates :is_arranged, inclusion: { in: [true, false] }

--- a/app/models/setlistitem.rb
+++ b/app/models/setlistitem.rb
@@ -12,4 +12,7 @@ class Setlistitem < ApplicationRecord
 
     self.song_id = @song.id
   end
+
+  def set_information
+  end
 end

--- a/app/models/setlistitem.rb
+++ b/app/models/setlistitem.rb
@@ -15,6 +15,6 @@ class Setlistitem < ApplicationRecord
   end
 
   def set_info
-    @infos = SetlistitemInformation.where(setlistitem_id: self.id)
+    @infos = SetlistitemInformation.where(setlistitem_id: id)
   end
 end

--- a/app/models/setlistitem_information.rb
+++ b/app/models/setlistitem_information.rb
@@ -3,6 +3,4 @@ class SetlistitemInformation < ApplicationRecord
   belongs_to :setlistitem
 
   validates :body, presence: true
-  validates :user_id, presence: true
-  validates :setlistitem_id, presence: true
 end

--- a/app/models/setlistitem_information.rb
+++ b/app/models/setlistitem_information.rb
@@ -1,0 +1,8 @@
+class SetlistitemInformation < ApplicationRecord
+  belongs_to :user
+  belongs_to :setlistitem
+
+  validates :body, presence: true
+  validates :user_id, presence: true
+  validates :setlistitem_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: [:twitter]
 
   has_many :setlists, dependent: :destroy
+  has_many :setlistitem_informations, dependent: :destroy
   has_many :song_informations, dependent: :destroy
   has_many :likes_on_song_informations, dependent: :destroy
   has_many :likes_on_tour_informations, dependent: :destroy

--- a/app/views/events/_setlistitem.html.erb
+++ b/app/views/events/_setlistitem.html.erb
@@ -5,7 +5,7 @@
       <div class="collapse-title text-xl font-medium">
         <p><%= song_display(item) %></p>
       </div>
-      <%= render 'setlistitems/setlistitem_information', new_info: @new_info %>
+      <%= render 'setlistitems/setlistitem_information', item: item %>
     </div>
   </div>
 <% end %>

--- a/app/views/events/_setlistitem.html.erb
+++ b/app/views/events/_setlistitem.html.erb
@@ -1,20 +1,11 @@
 <% setlistitems.each do |item| %>
   <div class="join join-vertical w-full">
     <div class="collapse collapse-arrow join-item border-base-300 border mb-5">
-    <input type="radio" name="my-accordion-4" checked="checked" />
+      <input type="radio" name="my-accordion-4" checked="checked" />
       <div class="collapse-title text-xl font-medium">
         <p><%= song_display(item) %></p>
       </div>
-    <div class="collapse-content">
-      <div class="card bg-base-100 w-96 shadow-xl">
-        <div class="card-body">
-          <h2 class="card-title">Card title!</h2>
-          <p>If a dog chews shoes whose shoes does he choose?</p>
-          <div class="card-actions justify-end">
-            <button class="btn btn-primary">Buy Now</button>
-          </div>
-        </div>
-      </div>
+      <%= render 'setlistitems/setlistitem_information', new_info: @new_info %>
     </div>
   </div>
 <% end %>

--- a/app/views/setlistitem_informations/create.html.erb
+++ b/app/views/setlistitem_informations/create.html.erb
@@ -1,0 +1,2 @@
+<h1>SetlistitemInformations#create</h1>
+<p>Find me in app/views/setlistitem_informations/create.html.erb</p>

--- a/app/views/setlistitems/_setlistitem_information.html.erb
+++ b/app/views/setlistitems/_setlistitem_information.html.erb
@@ -2,8 +2,9 @@
   <div class="card bg-base-100 w-96 shadow-xl">
     <div class="card-body">
       <h2 class="card-title">コメントを投稿しましょう！</h2>
-      <%= form_with model: new_info do |f| %>
-        <%= f.text_area :body, class: "textarea", placeholder: "コメントを入力" %>
+      <%= form_with model: SetlistitemInformation.new, url: setlistitem_informations_path do |f| %>
+        <%= f.text_area :body, class: "textarea w-full", placeholder: "コメントを入力" %>
+        <%= f.hidden_field :setlistitem_id, value: item.id %>
         <div class="card-actions justify-end">
           <%= f.submit '投稿', class: "btn btn-primary" %>
         </div>

--- a/app/views/setlistitems/_setlistitem_information.html.erb
+++ b/app/views/setlistitems/_setlistitem_information.html.erb
@@ -1,0 +1,13 @@
+<div class="collapse-content">
+  <div class="card bg-base-100 w-96 shadow-xl">
+    <div class="card-body">
+      <h2 class="card-title">コメントを投稿しましょう！</h2>
+      <%= form_with model: new_info do |f| %>
+        <%= f.text_area :body, class: "textarea", placeholder: "コメントを入力" %>
+        <div class="card-actions justify-end">
+          <%= f.submit '投稿', class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
     resource :setlist, only: [:new, :create]
   end
 
+  resources :setlistitem_informations, only: [:create]
+
   # セットリストのオートコンプリートのためのルーティング
   resources :setlists do
     get :search, on: :collection

--- a/db/migrate/20241104122410_create_setlistitem_informations.rb
+++ b/db/migrate/20241104122410_create_setlistitem_informations.rb
@@ -1,0 +1,11 @@
+class CreateSetlistitemInformations < ActiveRecord::Migration[7.2]
+  def change
+    create_table :setlistitem_informations do |t|
+      t.integer :user_id, null: false
+      t.integer :setlistitem_id, null: false
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_122410) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "setlist_informations", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "setlistitem_id", null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "setlistitem_informations", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "setlistitem_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_02_015705) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_04_122410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_02_015705) do
   create_table "likes_on_tour_informations", force: :cascade do |t|
     t.integer "user_id"
     t.integer "tour_information_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "setlistitem_informations", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "setlistitem_id", null: false
+    t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/controllers/setlistitem_informations_controller_test.rb
+++ b/test/controllers/setlistitem_informations_controller_test.rb
@@ -1,7 +1,7 @@
-require "test_helper"
+require 'test_helper'
 
 class SetlistitemInformationsControllerTest < ActionDispatch::IntegrationTest
-  test "should get create" do
+  test 'should get create' do
     get setlistitem_informations_create_url
     assert_response :success
   end

--- a/test/controllers/setlistitem_informations_controller_test.rb
+++ b/test/controllers/setlistitem_informations_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SetlistitemInformationsControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get setlistitem_informations_create_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/setlistitem_informations.yml
+++ b/test/fixtures/setlistitem_informations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  setlistitem_id: 1
+  body: MyText
+
+two:
+  user_id: 1
+  setlistitem_id: 1
+  body: MyText

--- a/test/models/setlistitem_information_test.rb
+++ b/test/models/setlistitem_information_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SetlistitemInformationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/setlistitem_information_test.rb
+++ b/test/models/setlistitem_information_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class SetlistitemInformationTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
## 概要
Setlistitemに対してSetlistitemInformationを投稿できるようにしました。
## 加えた変更
* SetlistitemInformationテーブル・モデル・コントローラの生成
* SetlistitemInformation投稿フォームの作成
* SetlistitemInformation投稿関連のアクションの作成

## 加えなかった変更
* 投稿されたSetlistitemInformationの表示
→後ほど対応します。

## 影響範囲

## 関連Issue
