### PR TITLE
add: イベント検索条件追加（開催済みか否か）

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,11 @@ class EventsController < ApplicationController
   def index
     @events = Event.category(params[:category]).order(date: :desc)
     @categories = params[:category]
+    if params[:date] && params[:date].include?("1")
+      @events = @events
+    else
+      @events = @events.where(date: ..Date.today)
+    end
   end
 
   def show

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,14 +6,20 @@
   <%= form_with model: @event, method: :get, local: true do |f| %>
     <div class="flex w-full flex-col">
       <%= f.label :category, Event.human_attribute_name(:category) %>
-      <div class="cursor-pointer">
+      <div>
         <%= f.collection_check_boxes :category, Event.categories, :first, :first do |s| %>
           <%= s.check_box checked: @category.nil? || @category.include?(s.value), class: "checkbox checkbox-xs" %>
           <%= s.label { Event.human_attribute_name("category.#{s.text}")} %>
         <% end %>
       </div>
+      <div>
+        <%= f.check_box :date, class: "checkbox checkbox-xs" %>
+        <%= f.label '開催前のイベントも表示' %>
+      </div>
     </div>
-    <%= f.submit "Go", class: "" %>
+    <button class="btn">
+      <%= f.submit "Go", class: "" %>
+    </button>
   <% end %>
 
   <div class="justify-center">


### PR DESCRIPTION
## 概要
イベント検索条件追加
## 加えた変更
* イベント一覧表示時、開催済みのもののみの表示をデフォルトにしました。
* 開催前のイベント表示ボタンを実装しました。

## 加えなかった変更
* コントローラにロジックの記述が偏ってしまっているので、後日修正します。

## 影響範囲

## 関連Issue
* close #25 
