### PR TITLE
Bugfix/seed file separate

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,48 +1,48 @@
-require "csv"
+# require "csv"
 
-CSV.foreach('db/csv/tours.csv', headers: true) do |row|
-  Tour.find_or_create_by!(name: row['name']) do |tour|
-    tour.name = row['name']
-    tour.name_kana_ruby = row['name_kana_ruby']
-  end
-end
+# CSV.foreach('db/csv/tours.csv', headers: true) do |row|
+#   Tour.find_or_create_by!(name: row['name']) do |tour|
+#     tour.name = row['name']
+#     tour.name_kana_ruby = row['name_kana_ruby']
+#   end
+# end
 
-CSV.foreach('db/csv/events.csv', headers: true) do |row|
-  Event.find_or_create_by!(name: row['name'], date: row['date']) do |event|
-    event.category = row['category']
-    event.name = row['name']
-    event.name_kana_ruby = row['name_kana_ruby']
-    event.date = row['date']
-    event.place = row['place']
-    event.place_prefecture = row['place_prefecture']
-    event.is_canceled = row['is_canceled']
-    event.remark = row['remark']
-    event.tour_id = row['tour_id']
-    if row['visual_image'].present? && File.exist?(Rails.root.join(row['visual_image']))
-      file = ImageProcessing::MiniMagick.source(File.open(Rails.root.join(row['visual_image']))).resize_to_fit(900, 900).call
-      begin
-      event.visual_image.attach(io: File.open(file.path),filename: File.basename(row['visual_image']))
-      ensure
-      file.close
-      file.unlink
-      end
-    end
-  end
-end
+# CSV.foreach('db/csv/events.csv', headers: true) do |row|
+#   Event.find_or_create_by!(name: row['name'], date: row['date']) do |event|
+#     event.category = row['category']
+#     event.name = row['name']
+#     event.name_kana_ruby = row['name_kana_ruby']
+#     event.date = row['date']
+#     event.place = row['place']
+#     event.place_prefecture = row['place_prefecture']
+#     event.is_canceled = row['is_canceled']
+#     event.remark = row['remark']
+#     event.tour_id = row['tour_id']
+#     if row['visual_image'].present? && File.exist?(Rails.root.join(row['visual_image']))
+#       file = ImageProcessing::MiniMagick.source(File.open(Rails.root.join(row['visual_image']))).resize_to_fit(900, 900).call
+#       begin
+#       event.visual_image.attach(io: File.open(file.path),filename: File.basename(row['visual_image']))
+#       ensure
+#       file.close
+#       file.unlink
+#       end
+#     end
+#   end
+# end
 
-CSV.foreach('db/csv/songs.csv', headers: true) do |row|
-  Song.find_or_create_by!(name: row['name']) do |song|
-    song.name = row['name']
-    song.name_kana_ruby = row['name_kana_ruby']
-    song.youtube_link = row['youtube']
-    if row['jk'].present? && File.exist?(Rails.root.join(row['jk']))
-      file = ImageProcessing::MiniMagick.source(File.open(Rails.root.join(row['jk']))).resize_to_fit(900, 900).call
-      begin
-      song.jk.attach(io: File.open(file.path),filename: File.basename(row['jk']))
-      ensure
-      file.close
-      file.unlink
-      end
-    end
-  end
-end
+# CSV.foreach('db/csv/songs.csv', headers: true) do |row|
+#   Song.find_or_create_by!(name: row['name']) do |song|
+#     song.name = row['name']
+#     song.name_kana_ruby = row['name_kana_ruby']
+#     song.youtube_link = row['youtube']
+#     if row['jk'].present? && File.exist?(Rails.root.join(row['jk']))
+#       file = ImageProcessing::MiniMagick.source(File.open(Rails.root.join(row['jk']))).resize_to_fit(900, 900).call
+#       begin
+#       song.jk.attach(io: File.open(file.path),filename: File.basename(row['jk']))
+#       ensure
+#       file.close
+#       file.unlink
+#       end
+#     end
+#   end
+# end

--- a/db/seeds/events_attach.rb
+++ b/db/seeds/events_attach.rb
@@ -1,0 +1,14 @@
+require "csv"
+
+CSV.foreach('db/csv/events.csv', headers: true) do |row|
+  event = Event.find_by(name: row['name'], date: row['date'])
+  if row['visual_image'].present? && File.exist?(Rails.root.join(row['visual_image']))
+    file = ImageProcessing::MiniMagick.source(File.open(Rails.root.join(row['visual_image']))).resize_to_fit(900, 900).call
+    begin
+    event.visual_image.attach(io: File.open(file.path),filename: File.basename(row['visual_image']))
+    ensure
+    file.close
+    file.unlink
+    end
+  end
+end

--- a/db/seeds/information.rb
+++ b/db/seeds/information.rb
@@ -1,0 +1,30 @@
+require "csv"
+
+CSV.foreach('db/csv/tours.csv', headers: true) do |row|
+  Tour.find_or_create_by!(name: row['name']) do |tour|
+    tour.name = row['name']
+    tour.name_kana_ruby = row['name_kana_ruby']
+  end
+end
+
+CSV.foreach('db/csv/events.csv', headers: true) do |row|
+  Event.find_or_create_by!(name: row['name'], date: row['date']) do |event|
+    event.category = row['category']
+    event.name = row['name']
+    event.name_kana_ruby = row['name_kana_ruby']
+    event.date = row['date']
+    event.place = row['place']
+    event.place_prefecture = row['place_prefecture']
+    event.is_canceled = row['is_canceled']
+    event.remark = row['remark']
+    event.tour_id = row['tour_id']
+  end
+end
+
+CSV.foreach('db/csv/songs.csv', headers: true) do |row|
+  Song.find_or_create_by!(name: row['name']) do |song|
+    song.name = row['name']
+    song.name_kana_ruby = row['name_kana_ruby']
+    song.youtube_link = row['youtube']
+  end
+end

--- a/db/seeds/songs_attach.rb
+++ b/db/seeds/songs_attach.rb
@@ -1,0 +1,14 @@
+require "csv"
+
+CSV.foreach('db/csv/songs.csv', headers: true) do |row|
+  song = Song.find_by(name: row['name'])
+  if row['jk'].present? && File.exist?(Rails.root.join(row['jk']))
+    file = ImageProcessing::MiniMagick.source(File.open(Rails.root.join(row['jk']))).resize_to_fit(900, 900).call
+    begin
+    song.jk.attach(io: File.open(file.path),filename: File.basename(row['jk']))
+    ensure
+    file.close
+    file.unlink
+    end
+  end
+end

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -1,0 +1,6 @@
+Dir.glob(File.join(Rails.root, 'db', 'seeds', '*.rb')).each do |file|
+  desc "Load the seed data from db/seeds/#{File.basename(file)}."
+  task "db:seed:#{File.basename(file).gsub(/\..+$/, '')}" => :environment do
+    load(file)
+  end
+end


### PR DESCRIPTION
## 概要
初期データ作成時に必要なメモリを削減するために、seedファイルを分割しました。
## 加えた変更
**【変更前】**
* `rails db:seed`で、データ作成・画像アタッチまで一括で行う。

**【変更後】**
* データ作成のseedファイル・画像アタッチの2ステップでデータを作成するように変更。
* [この記事](https://yu0105teshi.hateblo.jp/entry/2016/08/03/180603)を元に、seedファイルを分割した。`bundle exec rake  db:seed:xxx`コマンドで、該当のseedファイルを実行するように変更。

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
