### PR TITLE
Feat/notification

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,8 @@ class ApplicationController < ActionController::Base
   private
 
   def any_unread_notice?
-    return unless user_signed_in?
+    return false unless user_signed_in?
+
     @unread_notice = Notice.find_by(user_id: current_user, unread: true)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: { safari: 15.0, chrome: 50, firefox: 121, ie: false }
   before_action :authenticate_user!
+  before_action :any_unread_notice?
+
+  private
+
+  def any_unread_notice?
+    return unless user_signed_in?
+    @notice = Notice.find_by(user_id: current_user, unread: true)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,6 @@ class ApplicationController < ActionController::Base
 
   def any_unread_notice?
     return unless user_signed_in?
-    @notice = Notice.find_by(user_id: current_user, unread: true)
+    @unread_notice = Notice.find_by(user_id: current_user, unread: true)
   end
 end

--- a/app/controllers/likes_on_event_informations_controller.rb
+++ b/app/controllers/likes_on_event_informations_controller.rb
@@ -3,7 +3,7 @@ class LikesOnEventInformationsController < ApplicationController
     event_information = EventInformation.find(params[:event_information_id])
     likes_on_event_information = current_user.likes_on_event_informations.new(event_information_id: event_information.id)
     likes_on_event_information.save
-    create_notice(event_information.user.id)
+    likes_on_event_information.create_notice(event_information.user)
     redirect_to event_path(id: event_information.event.id)
   end
 

--- a/app/controllers/likes_on_event_informations_controller.rb
+++ b/app/controllers/likes_on_event_informations_controller.rb
@@ -3,14 +3,12 @@ class LikesOnEventInformationsController < ApplicationController
     event_information = EventInformation.find(params[:event_information_id])
     likes_on_event_information = current_user.likes_on_event_informations.new(event_information_id: event_information.id)
     likes_on_event_information.save
-    likes_on_event_information.create_notice(event_information.user)
     redirect_to event_path(id: event_information.event.id)
   end
 
   def destroy
     event_information = EventInformation.find(params[:event_information_id])
     likes_on_event_information = current_user.likes_on_event_informations.find_by(event_information_id: event_information.id)
-    likes_on_event_information.destroy_notice(event_information.user)
     likes_on_event_information.destroy
     redirect_to event_path(id: event_information.event.id)
   end

--- a/app/controllers/likes_on_event_informations_controller.rb
+++ b/app/controllers/likes_on_event_informations_controller.rb
@@ -10,6 +10,7 @@ class LikesOnEventInformationsController < ApplicationController
   def destroy
     event_information = EventInformation.find(params[:event_information_id])
     likes_on_event_information = current_user.likes_on_event_informations.find_by(event_information_id: event_information.id)
+    likes_on_event_information.destroy_notice(event_information.user)
     likes_on_event_information.destroy
     redirect_to event_path(id: event_information.event.id)
   end

--- a/app/controllers/likes_on_event_informations_controller.rb
+++ b/app/controllers/likes_on_event_informations_controller.rb
@@ -3,6 +3,7 @@ class LikesOnEventInformationsController < ApplicationController
     event_information = EventInformation.find(params[:event_information_id])
     likes_on_event_information = current_user.likes_on_event_informations.new(event_information_id: event_information.id)
     likes_on_event_information.save
+    create_notice(event_information.user.id)
     redirect_to event_path(id: event_information.event.id)
   end
 

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,5 +1,6 @@
 class NoticesController < ApplicationController
-  def create
+  def index
+    @notices = Notice.where(user_id: current_user.id)
   end
 
   def destroy

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,6 +1,6 @@
 class NoticesController < ApplicationController
   def index
-    @notices = Notice.where(user_id: current_user.id)
+    @notices = Notice.where(user_id: current_user.id).includes(noticeable: :user).order(created_at: :desc)
   end
 
   def destroy

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,0 +1,7 @@
+class NoticesController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -5,16 +5,10 @@ class NoticesController < ApplicationController
 
   def destroy
     @notices = Notice.where(user_id: current_user.id, unread: true).includes(noticeable: :user).order(created_at: :desc)
-    @notices.update_to_read
-    redirect_to notices_path
-  end
-
-  private
-
-  def update_to_read
-    self.each do |notice|
+    @notices.each do |notice|
       notice.unread = false
       notice.save
     end
+    redirect_to notices_path
   end
 end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -4,5 +4,17 @@ class NoticesController < ApplicationController
   end
 
   def destroy
+    @notices = Notice.where(user_id: current_user.id, unread: true).includes(noticeable: :user).order(created_at: :desc)
+    @notices.update_to_read
+    redirect_to notices_path
+  end
+
+  private
+
+  def update_to_read
+    self.each do |notice|
+      notice.unread = false
+      notice.save
+    end
   end
 end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,6 +1,6 @@
 class NoticesController < ApplicationController
   def index
-    @notices = Notice.where(user_id: current_user.id).includes(noticeable: :user).order(created_at: :desc)
+    @notices = Notice.where(user_id: current_user.id, unread: true).includes(noticeable: :user).order(created_at: :desc)
   end
 
   def destroy

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -1,0 +1,2 @@
+module NoticesHelper
+end

--- a/app/models/likes_on_event_information.rb
+++ b/app/models/likes_on_event_information.rb
@@ -4,13 +4,18 @@ class LikesOnEventInformation < ApplicationRecord
 
   has_many :notices, as: :noticeable, dependent: :destroy
 
-  def create_notice(user)
-    @notice = Notice.new(noticeable_type: LikesOnEventInformation, noticeable_id: self.id, user_id: user.id, action_type: Notice.action_types[:like])
+  after_create :create_notice
+  before_destroy :destroy_notice
+
+  private
+
+  def create_notice
+    @notice = Notice.new(noticeable_type: LikesOnEventInformation, noticeable_id: self.id, user_id: self.user.id, action_type: Notice.action_types[:like])
     @notice.save
   end
 
-  def destroy_notice(user)
-    @notice = Notice.find_by(noticeable_type: "LikesOnEventInformation", noticeable_id: self.id, user_id: user.id)
-    @notice.destroy
+  def destroy_notice
+    @notice = Notice.find_by(noticeable_type: "LikesOnEventInformation", noticeable_id: self.id, user_id: self.user.id)
+    @notice.destroy if @notice.present?
   end
 end

--- a/app/models/likes_on_event_information.rb
+++ b/app/models/likes_on_event_information.rb
@@ -3,4 +3,10 @@ class LikesOnEventInformation < ApplicationRecord
   belongs_to :event_information_id
 
   has_many :notices, as: :noticeable, dependent: :destroy
+
+  private
+
+  def create_notice(user)
+    Notice.create!(noticeable: self, user_id: user.id, action_type: Notice.action_types[:liked])
+  end
 end

--- a/app/models/likes_on_event_information.rb
+++ b/app/models/likes_on_event_information.rb
@@ -1,4 +1,6 @@
 class LikesOnEventInformation < ApplicationRecord
   belongs_to :user
-  belongs_to :event_information
+  belongs_to :event_information_id
+
+  has_many :notices, as: :noticeable, dependent: :destroy
 end

--- a/app/models/likes_on_event_information.rb
+++ b/app/models/likes_on_event_information.rb
@@ -8,4 +8,9 @@ class LikesOnEventInformation < ApplicationRecord
     @notice = Notice.new(noticeable_type: LikesOnEventInformation, noticeable_id: self.id, user_id: user.id, action_type: Notice.action_types[:like])
     @notice.save
   end
+
+  def destroy_notice(user)
+    @notice = Notice.find_by(noticeable_type: "LikesOnEventInformation", noticeable_id: self.id, user_id: user.id)
+    @notice.destroy
+  end
 end

--- a/app/models/likes_on_event_information.rb
+++ b/app/models/likes_on_event_information.rb
@@ -10,12 +10,13 @@ class LikesOnEventInformation < ApplicationRecord
   private
 
   def create_notice
-    @notice = Notice.new(noticeable_type: LikesOnEventInformation, noticeable_id: self.id, user_id: self.user.id, action_type: Notice.action_types[:like])
+    @notice = Notice.new(noticeable_type: LikesOnEventInformation, noticeable_id: id, user_id: user.id,
+                         action_type: Notice.action_types[:like])
     @notice.save
   end
 
   def destroy_notice
-    @notice = Notice.find_by(noticeable_type: "LikesOnEventInformation", noticeable_id: self.id, user_id: self.user.id)
+    @notice = Notice.find_by(noticeable_type: 'LikesOnEventInformation', noticeable_id: id, user_id: user.id)
     @notice.destroy if @notice.present?
   end
 end

--- a/app/models/likes_on_event_information.rb
+++ b/app/models/likes_on_event_information.rb
@@ -4,9 +4,8 @@ class LikesOnEventInformation < ApplicationRecord
 
   has_many :notices, as: :noticeable, dependent: :destroy
 
-  private
-
   def create_notice(user)
-    Notice.create!(noticeable: self, user_id: user.id, action_type: Notice.action_types[:like])
+    @notice = Notice.new(noticeable_type: LikesOnEventInformation, noticeable_id: self.id, user_id: user.id, action_type: Notice.action_types[:like])
+    @notice.save
   end
 end

--- a/app/models/likes_on_event_information.rb
+++ b/app/models/likes_on_event_information.rb
@@ -1,12 +1,12 @@
 class LikesOnEventInformation < ApplicationRecord
   belongs_to :user
-  belongs_to :event_information_id
+  belongs_to :event_information
 
   has_many :notices, as: :noticeable, dependent: :destroy
 
   private
 
   def create_notice(user)
-    Notice.create!(noticeable: self, user_id: user.id, action_type: Notice.action_types[:liked])
+    Notice.create!(noticeable: self, user_id: user.id, action_type: Notice.action_types[:like])
   end
 end

--- a/app/models/likes_on_setlistitem_information.rb
+++ b/app/models/likes_on_setlistitem_information.rb
@@ -10,12 +10,13 @@ class LikesOnSetlistitemInformation < ApplicationRecord
   private
 
   def create_notice
-    @notice = Notice.new(noticeable_type: LikesOnSetlistitemInformation, noticeable_id: self.id, user_id: self.user.id, action_type: Notice.action_types[:like])
+    @notice = Notice.new(noticeable_type: LikesOnSetlistitemInformation, noticeable_id: id, user_id: user.id,
+                         action_type: Notice.action_types[:like])
     @notice.save
   end
 
   def destroy_notice
-    @notice = Notice.find_by(noticeable_type: "LikesOnSetlistitemInformation", noticeable_id: self.id, user_id: self.user.id)
+    @notice = Notice.find_by(noticeable_type: 'LikesOnSetlistitemInformation', noticeable_id: id, user_id: user.id)
     @notice.destroy if @notice.present?
   end
 end

--- a/app/models/likes_on_setlistitem_information.rb
+++ b/app/models/likes_on_setlistitem_information.rb
@@ -1,4 +1,6 @@
 class LikesOnSetlistitemInformation < ApplicationRecord
   belongs_to :user
   belongs_to :setlistitem_information
+
+  has_many :notices, as: :noticeable, dependent: :destroy
 end

--- a/app/models/likes_on_setlistitem_information.rb
+++ b/app/models/likes_on_setlistitem_information.rb
@@ -3,4 +3,19 @@ class LikesOnSetlistitemInformation < ApplicationRecord
   belongs_to :setlistitem_information
 
   has_many :notices, as: :noticeable, dependent: :destroy
+
+  after_create :create_notice
+  before_destroy :destroy_notice
+
+  private
+
+  def create_notice
+    @notice = Notice.new(noticeable_type: LikesOnSetlistitemInformation, noticeable_id: self.id, user_id: self.user.id, action_type: Notice.action_types[:like])
+    @notice.save
+  end
+
+  def destroy_notice
+    @notice = Notice.find_by(noticeable_type: "LikesOnSetlistitemInformation", noticeable_id: self.id, user_id: self.user.id)
+    @notice.destroy if @notice.present?
+  end
 end

--- a/app/models/likes_on_song_information.rb
+++ b/app/models/likes_on_song_information.rb
@@ -3,4 +3,19 @@ class LikesOnSongInformation < ApplicationRecord
   belongs_to :song_information
 
   has_many :notices, as: :noticeable, dependent: :destroy
+
+  after_create :create_notice
+  before_destroy :destroy_notice
+
+  private
+
+  def create_notice
+    @notice = Notice.new(noticeable_type: LikesOnSongInformation, noticeable_id: self.id, user_id: self.user.id, action_type: Notice.action_types[:like])
+    @notice.save
+  end
+
+  def destroy_notice
+    @notice = Notice.find_by(noticeable_type: "LikesOnSongInformation", noticeable_id: self.id, user_id: self.user.id)
+    @notice.destroy if @notice.present?
+  end
 end

--- a/app/models/likes_on_song_information.rb
+++ b/app/models/likes_on_song_information.rb
@@ -1,4 +1,6 @@
 class LikesOnSongInformation < ApplicationRecord
   belongs_to :user
   belongs_to :song_information
+
+  has_many :notices, as: :noticeable, dependent: :destroy
 end

--- a/app/models/likes_on_song_information.rb
+++ b/app/models/likes_on_song_information.rb
@@ -10,12 +10,13 @@ class LikesOnSongInformation < ApplicationRecord
   private
 
   def create_notice
-    @notice = Notice.new(noticeable_type: LikesOnSongInformation, noticeable_id: self.id, user_id: self.user.id, action_type: Notice.action_types[:like])
+    @notice = Notice.new(noticeable_type: LikesOnSongInformation, noticeable_id: id, user_id: user.id,
+                         action_type: Notice.action_types[:like])
     @notice.save
   end
 
   def destroy_notice
-    @notice = Notice.find_by(noticeable_type: "LikesOnSongInformation", noticeable_id: self.id, user_id: self.user.id)
+    @notice = Notice.find_by(noticeable_type: 'LikesOnSongInformation', noticeable_id: id, user_id: user.id)
     @notice.destroy if @notice.present?
   end
 end

--- a/app/models/likes_on_tour_information.rb
+++ b/app/models/likes_on_tour_information.rb
@@ -3,4 +3,19 @@ class LikesOnTourInformation < ApplicationRecord
   belongs_to :tour_information
 
   has_many :notices, as: :noticeable, dependent: :destroy
+
+  after_create :create_notice
+  before_destroy :destroy_notice
+
+  private
+
+  def create_notice
+    @notice = Notice.new(noticeable_type: LikesOnTourInformation, noticeable_id: self.id, user_id: self.user.id, action_type: Notice.action_types[:like])
+    @notice.save
+  end
+
+  def destroy_notice
+    @notice = Notice.find_by(noticeable_type: "LikesOnTourInformation", noticeable_id: self.id, user_id: self.user.id)
+    @notice.destroy if @notice.present?
+  end
 end

--- a/app/models/likes_on_tour_information.rb
+++ b/app/models/likes_on_tour_information.rb
@@ -1,4 +1,6 @@
 class LikesOnTourInformation < ApplicationRecord
   belongs_to :user
   belongs_to :tour_information
+
+  has_many :notices, as: :noticeable, dependent: :destroy
 end

--- a/app/models/likes_on_tour_information.rb
+++ b/app/models/likes_on_tour_information.rb
@@ -10,12 +10,13 @@ class LikesOnTourInformation < ApplicationRecord
   private
 
   def create_notice
-    @notice = Notice.new(noticeable_type: LikesOnTourInformation, noticeable_id: self.id, user_id: self.user.id, action_type: Notice.action_types[:like])
+    @notice = Notice.new(noticeable_type: LikesOnTourInformation, noticeable_id: id, user_id: user.id,
+                         action_type: Notice.action_types[:like])
     @notice.save
   end
 
   def destroy_notice
-    @notice = Notice.find_by(noticeable_type: "LikesOnTourInformation", noticeable_id: self.id, user_id: self.user.id)
+    @notice = Notice.find_by(noticeable_type: 'LikesOnTourInformation', noticeable_id: id, user_id: user.id)
     @notice.destroy if @notice.present?
   end
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,0 +1,2 @@
+class Notice < ApplicationRecord
+end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -2,5 +2,5 @@ class Notice < ApplicationRecord
   belongs_to :noticeable, polymorphic: true
   belongs_to :user
 
-  enum :action_type, { liked: 0, commented: 1 }
+  enum :action_type, { like: 0, comment: 1 }
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -2,7 +2,5 @@ class Notice < ApplicationRecord
   belongs_to :noticeable, polymorphic: true
   belongs_to :user
 
-  enum action_type: {
-    like:  0
-  }
+  enum :action_type, { liked: 0, commented: 1 }
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,2 +1,4 @@
 class Notice < ApplicationRecord
+  belongs_to :noticeable, polymorphic: true
+  belongs_to :user
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,4 +1,8 @@
 class Notice < ApplicationRecord
   belongs_to :noticeable, polymorphic: true
   belongs_to :user
+
+  enum action_type: {
+    like:  0
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :likes_on_tour_informations, dependent: :destroy
   has_many :likes_on_event_informations, dependent: :destroy
   has_many :likes_on_setlistitem_informations, dependent: :destroy
+  has_many :notices, dependent: :destroy
 
   # Twitter認証ログイン用
   # ユーザーの情報があれば探し、無ければ作成する

--- a/app/views/notices/_notice.html.erb
+++ b/app/views/notices/_notice.html.erb
@@ -1,18 +1,23 @@
 <% notices.each do |notice| %>
+  <div class="mb-5">
   <% if notice.action_type = "like" %>
+    <div class="avatar flex items-center">
+      <div class="w-8 md:w-12 lg:w-16 rounded-xl">
+        <img src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"
+        alt="Tailwind-CSS-Avatar-component" />
+      </div>
+      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
+    </div>
     <% case notice.noticeable %>
     <% when LikesOnEventInformation %>
-      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
       <p><%= notice.noticeable.event_information.body %></p>
     <% when LikesOnTourInformation %>
-      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
       <p><%= notice.noticeable.tour_information.body %></p>
     <% when LikesOnSetlistitemInformation %>
-      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
       <p><%= notice.noticeable.setlistitem_information.body %></p>
     <% when LikesOnSongInformation %>
-      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
       <p><%= notice.noticeable.song_information.body %></p>
     <% end %>
   <% end %>
+  </div>
 <% end %>

--- a/app/views/notices/_notice.html.erb
+++ b/app/views/notices/_notice.html.erb
@@ -5,7 +5,7 @@
       <div class="w-8 md:w-12 lg:w-16 mr-3 rounded-xl">
         <%= image_tag notice.noticeable.user.image %>
       </div>
-      <p class="mr-3"><%= notice.noticeable.user.name.truncate(3) %>さんがいいねしました！</p>
+      <p class="mr-3"><%= notice.noticeable.user.name.truncate(7) %>さんがいいねしました！</p>
       <p class="stat-desc font-light"><%= time_ago_in_words(notice.created_at) %>前<p>
     </div>
     <% case notice.noticeable %>

--- a/app/views/notices/_notice.html.erb
+++ b/app/views/notices/_notice.html.erb
@@ -1,3 +1,18 @@
 <% notices.each do |notice| %>
-  <p><%= notice.noticeable.user.name %></p>
+  <% if notice.action_type = "like" %>
+    <% case notice.noticeable %>
+    <% when LikesOnEventInformation %>
+      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
+      <p><%= notice.noticeable.event_information.body %></p>
+    <% when LikesOnTourInformation %>
+      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
+      <p><%= notice.noticeable.tour_information.body %></p>
+    <% when LikesOnSetlistitemInformation %>
+      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
+      <p><%= notice.noticeable.setlistitem_information.body %></p>
+    <% when LikesOnSongInformation %>
+      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
+      <p><%= notice.noticeable.song_information.body %></p>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/notices/_notice.html.erb
+++ b/app/views/notices/_notice.html.erb
@@ -1,0 +1,3 @@
+<% notices.each do |notice| %>
+  <p><%= notice.noticeable.user.name %></p>
+<% end %>

--- a/app/views/notices/_notice.html.erb
+++ b/app/views/notices/_notice.html.erb
@@ -1,12 +1,12 @@
 <% notices.each do |notice| %>
   <div class="mb-5">
   <% if notice.action_type = "like" %>
-    <div class="avatar flex items-center">
-      <div class="w-8 md:w-12 lg:w-16 rounded-xl">
-        <img src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"
-        alt="Tailwind-CSS-Avatar-component" />
+    <div class="avatar flex items-center mb-3">
+      <div class="w-8 md:w-12 lg:w-16 mr-3 rounded-xl">
+        <%= image_tag notice.noticeable.user.image %>
       </div>
-      <p><%= notice.noticeable.user.name %>からいいねがありました。</p>
+      <p class="mr-3"><%= notice.noticeable.user.name.truncate(3) %>さんがいいねしました！</p>
+      <p class="stat-desc font-light"><%= time_ago_in_words(notice.created_at) %>前<p>
     </div>
     <% case notice.noticeable %>
     <% when LikesOnEventInformation %>

--- a/app/views/notices/create.html.erb
+++ b/app/views/notices/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Notices#create</h1>
+<p>Find me in app/views/notices/create.html.erb</p>

--- a/app/views/notices/destroy.html.erb
+++ b/app/views/notices/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Notices#destroy</h1>
+<p>Find me in app/views/notices/destroy.html.erb</p>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,8 +1,7 @@
 <h1>Notices#index</h1>
 
-<%= link_to "すべて既読", "/notices", data: { "turbo-method": :delete } %>
-
 <% if @notices.present? %>
+  <%= link_to "すべて既読", "/notices", data: { "turbo-method": :delete }, class: "btn btn-neutral" %>
   <%= render partial: "notice", locals: {notices: @notices} %>
 <% else %>
   <p>通知はありません。</p>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,5 +1,7 @@
 <h1>Notices#index</h1>
 
+<%= link_to "すべて既読", "/notices", data: { "turbo-method": :delete } %>
+
 <% if @notices.present? %>
   <%= render partial: "notice", locals: {notices: @notices} %>
 <% else %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,2 +1,2 @@
 <h1>Notices#index</h1>
-<p>Find me in app/views/notices/create.html.erb</p>
+<p><%= @notices.length %></p>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,9 +1,7 @@
 <h1>Notices#index</h1>
 
 <% if @notices.present? %>
-  <% @notices.each do |notice| %>
-    <p><%= notice.noticeable.user.name %></p>
-  <% end %>
+  <%= render partial: "notice", locals: {notices: @notices} %>
 <% else %>
   <p>通知はありません。</p>
 <% end %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,2 +1,2 @@
-<h1>Notices#create</h1>
+<h1>Notices#index</h1>
 <p>Find me in app/views/notices/create.html.erb</p>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,2 +1,9 @@
 <h1>Notices#index</h1>
-<p><%= @notices.length %></p>
+
+<% if @notices.present? %>
+  <% @notices.each do |notice| %>
+    <p><%= notice.noticeable.user.name %></p>
+  <% end %>
+<% else %>
+  <p>通知はありません。</p>
+<% end %>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -28,9 +28,7 @@
     <a class="btn btn-ghost text-xl">大衆情報局</a>
   </div>
 
-<% 
-=begin
-%>
+  # 通知ボタン
   <div class="navbar-end">
     <button class="btn btn-ghost btn-circle">
       <div class="indicator">
@@ -50,8 +48,4 @@
       </div>
     </button>
   </div>
-<%
-=end
-%>
-
 </div>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -29,7 +29,7 @@
   </div>
 
   <div class="navbar-end">
-    <button class="btn btn-ghost btn-circle">
+    <%= link_to notices_path, class: "btn btn-ghost btn-circle" do %>
       <div class="indicator">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -47,6 +47,6 @@
           <span class="badge badge-xs badge-primary indicator-item"></span>
         <% end %>
       </div>
-    </button>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -43,7 +43,9 @@
             stroke-width="2"
             d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
         </svg>
-        <span class="badge badge-xs badge-primary indicator-item"></span>
+        <% if @unread_notice.present? %>
+          <span class="badge badge-xs badge-primary indicator-item"></span>
+        <% end %>
       </div>
     </button>
   </div>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -28,7 +28,6 @@
     <a class="btn btn-ghost text-xl">大衆情報局</a>
   </div>
 
-  # 通知ボタン
   <div class="navbar-end">
     <button class="btn btn-ghost btn-circle">
       <div class="indicator">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,40 @@
 ja:
+  datetime:
+    distance_in_words:
+      half_a_minute: "30秒前後"
+      less_than_x_seconds:
+        one:   "1秒"
+        other: "%{count}秒"
+      x_seconds:
+        one:   "1秒"
+        other: "%{count}秒"
+      less_than_x_minutes:
+        one:   "1分"
+        other: "%{count}分"
+      x_minutes:
+        one:   "1分"
+        other: "%{count}分"
+      about_x_hours:
+        one:   "1時間"
+        other: "%{count}時間"
+      x_days:
+        one:   "1日"
+        other: "%{count}日"
+      about_x_months:
+        one:   "1ヶ月"
+        other: "%{count}ヶ月"
+      x_months:
+        one:   "1ヶ月"
+        other: "%{count}ヶ月"
+      almost_x_years:
+        one:   "１年"
+        other: "%{count}年"
+      about_x_years:
+        one:   "1年"
+        other: "%{count}年"
+      over_x_years:
+        one:   "1年以上"
+        other: "%{count}年以上"
   model:
     song:
       validates:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,8 @@ Rails.application.routes.draw do
     :omniauth_callbacks => 'users/omniauth_callbacks',
   }
 
-  resources :notices, only: [:index, :destroy]
+  resources :notices, only: [:index]
+  delete "notices" => "notices#destroy"
 
   resources :tours, only: [:index, :show] do
     resources :tour_informations, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     :omniauth_callbacks => 'users/omniauth_callbacks',
   }
 
-  resources :notices, only: [:create, :destroy]
+  resources :notices, only: [:index, :destroy]
 
   resources :tours, only: [:index, :show] do
     resources :tour_informations, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  get "likes_on_tour_informations/create"
-  get "likes_on_tour_informations/destroy"
   root "static_pages#top"
 
   devise_for :users, controllers: {
@@ -10,6 +8,8 @@ Rails.application.routes.draw do
     # Twitter API認証用
     :omniauth_callbacks => 'users/omniauth_callbacks',
   }
+
+  resources :notices, only: [:create, :destroy]
 
   resources :tours, only: [:index, :show] do
     resources :tour_informations, only: [:create]

--- a/db/migrate/20241117052617_create_notices.rb
+++ b/db/migrate/20241117052617_create_notices.rb
@@ -1,0 +1,12 @@
+class CreateNotices < ActiveRecord::Migration[8.0]
+  def change
+    create_table :notices do |t|
+      t.integer :user_id
+      t.references :noticeable, polymorphic: true
+      t.integer :action_type, null: false
+      t.boolean :unread, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_16_124412) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_17_052617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -93,6 +93,17 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_16_124412) do
     t.integer "tour_information_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "notices", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "noticeable_type"
+    t.bigint "noticeable_id"
+    t.integer "action_type", null: false
+    t.boolean "unread", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["noticeable_type", "noticeable_id"], name: "index_notices_on_noticeable"
   end
 
   create_table "setlist_informations", force: :cascade do |t|

--- a/test/controllers/notices_controller_test.rb
+++ b/test/controllers/notices_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class NoticesControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get notices_create_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get notices_destroy_url
+    assert_response :success
+  end
+end

--- a/test/controllers/notices_controller_test.rb
+++ b/test/controllers/notices_controller_test.rb
@@ -1,12 +1,12 @@
-require "test_helper"
+require 'test_helper'
 
 class NoticesControllerTest < ActionDispatch::IntegrationTest
-  test "should get create" do
+  test 'should get create' do
     get notices_create_url
     assert_response :success
   end
 
-  test "should get destroy" do
+  test 'should get destroy' do
     get notices_destroy_url
     assert_response :success
   end

--- a/test/fixtures/notices.yml
+++ b/test/fixtures/notices.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  noticeable_type: MyString
+  noticeable_id: 1
+
+two:
+  user_id: 1
+  noticeable_type: MyString
+  noticeable_id: 1

--- a/test/models/notice_test.rb
+++ b/test/models/notice_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NoticeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/notice_test.rb
+++ b/test/models/notice_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class NoticeTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
## 概要
通知機能の実装
## 加えた変更
* noticesテーブル追加・リレーション記述
  [ポリモーフィック](https://railsguides.jp/association_basics.html#has-many-through%E9%96%A2%E9%80%A3%E4%BB%98%E3%81%91)で関連付けを行いました。
* noticesのindexページ作成
* noticesの`index`・`destroy`アクション記述
  * `index`アクション：ユーザーの、未読の`notices`を取得。
  * `destroy`アクション：ユーザーの`notices`を全て既読にする。
* 全アクションの前に`any_unread_notice?`アクションを実行。
  `any_unread_notice?`アクション：ユーザーが一件でも未読の通知を所有しているか判定。

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #67 
