### PR TITLE
Fix イベント・楽曲一覧の写真表示を削除しました

### DIFF
--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,6 +1,6 @@
 <div class="card w-full shadow-2xl mb-2">
   <figure class="mt-10">
-    <%= image_tag 'default_people_1.jpg' %>
+    <%#= image_tag 'default_people_1.jpg' %>
     <%# if event.visual_image.attached? %>
       <%#= image_tag event.visual_image.variant(resize_to_fill: [250, 200]) %>
     <%# end %>

--- a/app/views/songs/_song.html.erb
+++ b/app/views/songs/_song.html.erb
@@ -1,6 +1,6 @@
-<div class="card shadow-2xl mb-5">
+<div class="card shadow-2xl mb-5 p-3">
   <figure>
-  <%= image_tag 'default_people_1.jpg' %>
+  <%#= image_tag 'default_people_1.jpg' %>
   <%# if song.jk.attached? %>
     <%#= image_tag song.jk.variant(resize_to_fill: [200, 200]) %>
   <%# end %>


### PR DESCRIPTION
## 概要
スクロールが大変という声が上がったため、一覧画面での写真表示を削除しました。

## 加えた変更
* 概要の通りです。

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
