### PR TITLE
Feat/future setlist prevent

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -45,6 +45,10 @@ class SetlistsController < ApplicationController
       flash[:error] = I18n.t('flash.error.cannot_post_setlist')
       redirect_to event_path(@event.id)
     end
+    if @event.date > Date.today
+      flash[:error] = I18n.t('flash.error.cannot_post_setlist')
+      redirect_to event_path(@event.id)
+    end
     return if @event.setlist.blank?
 
     flash[:error] = I18n.t('flash.error.setlist_exist')

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -45,7 +45,7 @@ class SetlistsController < ApplicationController
       flash[:error] = I18n.t('flash.error.cannot_post_setlist')
       redirect_to event_path(@event.id)
     end
-    if @event.date > Date.today
+    if @event.date > Time.zone.today
       flash[:error] = I18n.t('flash.error.cannot_post_setlist')
       redirect_to event_path(@event.id)
     end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -74,9 +74,11 @@
     </div>
     <%= render partial: 'events/setlistitem', locals: {setlistitems: @setlistitems, infos: @infos} %>
   <% elsif @event.is_canceled? %>
-    <p class="mb-3">開催見合わせのため、セットリスト情報はありません。</p>
+    <p class="mb-8">開催見合わせのため、セットリスト情報はありません。</p>
+  <% elsif @event.date > Date.today %>
+    <p class="mb-8">開催前のイベントにセットリストは投稿できません。</p>
   <% else %>
-    <p class="mb-3">セットリストはまだ投稿されていません。投稿にご協力お願いします！🙇</p>
+    <p class="mb-8">セットリストはまだ投稿されていません。投稿にご協力お願いします！🙇</p>
     <%= link_to "セットリストを投稿", new_event_setlist_path(params[:id]), class: 'btn btn-primary mb-5' %>
   <% end %>
 


### PR DESCRIPTION
## 概要
開催前のセットリストは登録できないようにしました。

## 加えた変更
* 開催前イベントのセットリスト登録ボタンを非表示
* 開催前イベントのセットリスト登録ページへの遷移・登録処理の防止

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #193 
