### PR TITLE
fix: 認証ページの背景写真変更

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div
   class="hero min-h-screen"
-  style="background-image: url(<%= asset_path "top.jpeg" %>);">
-  <div class="hero-overlay bg-opacity-60"></div>
+  style="background-image: url(<%= asset_path "top.png" %>);">
+  <div class="hero-overlay bg-opacity-40"></div>
   <div class="hero-content text-neutral-content text-center">
     <div class="max-w-md text-slate-100">
       <h1 class="text-2xl md:text-3xl mb-5 font-bold">ここから先は<br>Xでのログインが必要です</h1>


### PR DESCRIPTION
## 概要
認証ページの背景写真を変更しました。

## 加えた変更
* 認証ページの背景写真
  【旧】
  <img width="413" alt="スクリーンショット 2024-12-15 18 47 59" src="https://github.com/user-attachments/assets/cff1a6d8-c02f-4be2-b4d9-41e503305714" />
  【新】
  <img width="431" alt="スクリーンショット 2024-12-15 18 48 38" src="https://github.com/user-attachments/assets/07dffdf8-c34f-459b-b877-f939a9173689" />

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
