### PR TITLE
Feat ヒストリー一覧ページの画像遅延読み込み実装

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -12,4 +12,9 @@ class HistoriesController < ApplicationController
     end
     @histories = Kaminari.paginate_array(@histories).page(params[:page]).per(20)
   end
+
+  def disc_image
+    @disc = Disc.find(params[:id])
+    @disc_version = DiscVersion.includes(jacket_attachment: :blob).where(disc_id: @disc.id).first
+  end
 end

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -17,4 +17,8 @@ class HistoriesController < ApplicationController
     @disc = Disc.find(params[:id])
     @disc_version = DiscVersion.includes(jacket_attachment: :blob).where(disc_id: @disc.id).first
   end
+
+  def event_image
+    @event = Event.includes(visual_image_attachment: :blob).find(params[:id])
+  end
 end

--- a/app/views/histories/_history.html.erb
+++ b/app/views/histories/_history.html.erb
@@ -30,11 +30,12 @@
             <%= image_tag 'default_people_1.jpg', class: "h-40" %>
           <% end %>
         <% when Disc %>
-          <% if history.disc_versions.first.jacket.attached? %>
-            <%= image_tag history.disc_versions.first.jacket.variant(resize_to_fill: [400, 400], format: :webp) %>
-          <% else %>
-            <%= image_tag 'default_people_1.jpg', class: "h-40" %>
-          <% end %>
+          <turbo-frame id="history_disc_<%= history.id %>" src="/history_discs/<%= history.id %>" loading="lazy">
+            <div class="my-3 flex">
+              <span class="loading loading-spinner loading-xs mr-1"></span>
+              <p class="text-center">画像読み込み中...</p>
+            </div>
+          </turbo-frame>
         <% end %>
       </div>
       <% case history %>

--- a/app/views/histories/_history.html.erb
+++ b/app/views/histories/_history.html.erb
@@ -24,11 +24,12 @@
       <div class="my-2">
         <% case history %>
         <% when Event %>
-          <% if history.visual_image.attached? %>
-            <%= image_tag history.visual_image.variant(resize_to_fill: [400, 400], format: :webp) %>
-          <% else %>
-            <%= image_tag 'default_people_1.jpg', class: "h-40" %>
-          <% end %>
+          <turbo-frame id="history_event_<%= history.id %>" src="/history_events/<%= history.id %>" loading="lazy">
+            <div class="my-3 flex">
+              <span class="loading loading-spinner loading-xs mr-1"></span>
+              <p class="text-center">画像読み込み中...</p>
+            </div>
+          </turbo-frame>
         <% when Disc %>
           <turbo-frame id="history_disc_<%= history.id %>" src="/history_discs/<%= history.id %>" loading="lazy">
             <div class="my-3 flex">

--- a/app/views/histories/disc_image.html.erb
+++ b/app/views/histories/disc_image.html.erb
@@ -1,0 +1,7 @@
+<turbo-frame id="history_disc_<%= @disc.id %>">
+  <% if @disc_version.jacket.attached? %>
+    <%= image_tag @disc_version.jacket.variant(resize_to_fill: [400, 400], format: :webp) %>
+  <% else %>
+    <%= image_tag 'default_people_1.jpg', class: "h-40" %>
+  <% end %>
+</turbo-frame>

--- a/app/views/histories/event_image.html.erb
+++ b/app/views/histories/event_image.html.erb
@@ -1,0 +1,7 @@
+<turbo-frame id="history_event_<%= @event.id %>">
+  <% if @event.visual_image.attached? %>
+    <%= image_tag @event.visual_image.variant(resize_to_fill: [400, 400], format: :webp) %>
+  <% else %>
+    <%= image_tag 'default_people_1.jpg', class: "h-40" %>
+  <% end %>
+</turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get '/visual_images/:id' => "events#image"
   get '/jacket/:id' => "songs#jacket"
   get '/version_jacket/:id' => "discs#jacket"
+  get '/history_discs/:id' => "histories#disc_image"
 
   # （ここから）Twitter認証以外を認めないようにルーティングを設定しようとした痕跡
   # devise_for :users, skip: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get '/jacket/:id' => "songs#jacket"
   get '/version_jacket/:id' => "discs#jacket"
   get '/history_discs/:id' => "histories#disc_image"
+  get '/history_events/:id' => "histories#event_image"
 
   # （ここから）Twitter認証以外を認めないようにルーティングを設定しようとした痕跡
   # devise_for :users, skip: :all


### PR DESCRIPTION
## 概要
ヒストリー一覧ページの画像が遅延読み込みで表示されるように変更しました。

## 加えた変更
* 各画像の遅延読み込み

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #316 
