### PR TITLE
Fix/ヒストリー一覧ページ レスポンシブ対応

### DIFF
--- a/app/views/histories/_histories.html.erb
+++ b/app/views/histories/_histories.html.erb
@@ -1,5 +1,5 @@
 <div class="">
-  <ul class="timeline timeline-vertical">
+  <ul class="timeline timeline-vertical timeline-compact">
     <% @histories.each_with_index do |history, i| %>
       <%= render partial: 'history', locals: { history: history, i: i + 1 } %>
     <% end %>

--- a/app/views/histories/_history.html.erb
+++ b/app/views/histories/_history.html.erb
@@ -1,6 +1,6 @@
 <li>
   <hr />
-    <div class="timeline-start">
+    <div class="timeline-start text-left text-sm md:text-lg lg:text-2xl">
       <% case history %>
       <% when Event %>
         <%= I18n.l(history.date, format: "%Y/%m/%d(%a)") %>
@@ -20,8 +20,8 @@
             clip-rule="evenodd" />
         </svg>
       </div>
-    <div class="timeline-end timeline-box flex flex-col bg-base-300 text-base-content my-3 w-full">
-      <div class="my-2">
+    <div class="timeline-end timeline-box flex bg-base-300 text-base-content my-3 w-full">
+      <div class="my-2 w-1/3 items-center justify-center">
         <% case history %>
         <% when Event %>
           <turbo-frame id="history_event_<%= history.id %>" src="/history_events/<%= history.id %>" loading="lazy">
@@ -39,16 +39,19 @@
           </turbo-frame>
         <% end %>
       </div>
-      <% case history %>
-      <% when Event %>
-        <%= history.name %><br>
-        ＠<%= history.place %><br>
-        開催
-      <% when Disc %>
-        <%= t("activerecord.attributes.disc.#{history.production_type}") %><br>
-        <%= history.title %><br>
-        解禁
-      <% end %>
+      <div class="divider divider-horizontal"></div>
+      <div class="flex items-center w-2/3 text-base md:text-lg lg:text-2xl">
+        <% case history %>
+        <% when Event %>
+          <%= history.name %>
+          ＠<%= history.place %><br>
+          開催
+        <% when Disc %>
+          <%= t("activerecord.attributes.disc.#{history.production_type}") %><br>
+          <%= history.title %><br>
+          解禁
+        <% end %>
+      </div>
     </div>
   <hr />
 </li>

--- a/app/views/histories/disc_image.html.erb
+++ b/app/views/histories/disc_image.html.erb
@@ -1,7 +1,9 @@
 <turbo-frame id="history_disc_<%= @disc.id %>">
-  <% if @disc_version.jacket.attached? %>
-    <%= image_tag @disc_version.jacket.variant(resize_to_fill: [400, 400], format: :webp) %>
-  <% else %>
-    <%= image_tag 'default_people_1.jpg', class: "h-40" %>
-  <% end %>
+  <div class="flex items-center justify-center">
+    <% if @disc_version.jacket.attached? %>
+      <%= image_tag @disc_version.jacket.variant(resize_to_fill: [400, 400], format: :webp) %>
+    <% else %>
+      <%= image_tag 'default_people_1.jpg' %>
+    <% end %>
+  </div>
 </turbo-frame>

--- a/app/views/histories/event_image.html.erb
+++ b/app/views/histories/event_image.html.erb
@@ -1,7 +1,9 @@
 <turbo-frame id="history_event_<%= @event.id %>">
-  <% if @event.visual_image.attached? %>
-    <%= image_tag @event.visual_image.variant(resize_to_fill: [400, 400], format: :webp) %>
-  <% else %>
-    <%= image_tag 'default_people_1.jpg', class: "h-40" %>
-  <% end %>
+  <div class="flex items-center justify-center">
+    <% if @event.visual_image.attached? %>
+      <%= image_tag @event.visual_image.variant(resize_to_fill: [400, 400], format: :webp) %>
+    <% else %>
+      <%= image_tag 'default_people_1.jpg' %>
+    <% end %>
+  </div>
 </turbo-frame>


### PR DESCRIPTION
## 概要
ヒストリー一覧ページをレスポンシブ対応させました。

## 加えた変更
* 一覧ページのレイアウト変更
* 一覧ページのレスポンシブ対応

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #318 
