### PR TITLE
【WIP】Fix ヒストリー一覧画面 微修正

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -2,12 +2,15 @@ class HistoriesController < ApplicationController
   def index
     @histories = []
     @histories << Event.all
-    @histories << Disc.all
+    @histories << Disc.all.select(:title, :release_date, :production_type, :id)
+    @histories << Disc.all.select(:title, :announcement_date, :production_type, :id)
     @histories << History.all
     @histories.flatten!.sort_by! do |history|
       if history.respond_to?('date')
         history.date
-      else
+      elsif history.respond_to?('announcement_date')
+        history.announcement_date
+      elsif history.respond_to?('release_date')
         history.release_date
       end
     end

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -2,8 +2,8 @@ class HistoriesController < ApplicationController
   def index
     @histories = []
     @histories << Event.all
-    @histories << Disc.all.select(:title, :release_date, :production_type, :id)
-    @histories << Disc.all.select(:title, :announcement_date, :production_type, :id)
+    @histories << Disc.select(:title, :release_date, :production_type, :id)
+    @histories << Disc.select(:title, :announcement_date, :production_type, :id)
     @histories << History.all
     @histories.flatten!.sort_by! do |history|
       if history.respond_to?('date')

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -10,4 +10,24 @@ class Disc < ApplicationRecord
   validates :production_type, presence: true
 
   enum :production_type, { single: 0, ep: 1, album: 2, movie: 3 }
+
+  def date_inspection(another_date)
+    if self.respond_to?('announcement_date')
+      self.announcement_date != another_date
+    elsif self.respond_to?('release_date')
+      self.release_date != another_date
+    end
+  end
+
+  def about_date
+    if self.respond_to?('announcement_date')
+      self.announcement_date
+    elsif self.respond_to?('release_date')
+      self.release_date
+    end
+  end
+
+  def has_release_date?
+    self.respond_to?('release_date')
+  end
 end

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -12,22 +12,22 @@ class Disc < ApplicationRecord
   enum :production_type, { single: 0, ep: 1, album: 2, movie: 3 }
 
   def date_inspection(another_date)
-    if self.respond_to?('announcement_date')
-      self.announcement_date != another_date
-    elsif self.respond_to?('release_date')
-      self.release_date != another_date
+    if respond_to?('announcement_date')
+      announcement_date != another_date
+    elsif respond_to?('release_date')
+      release_date != another_date
     end
   end
 
   def about_date
-    if self.respond_to?('announcement_date')
-      self.announcement_date
-    elsif self.respond_to?('release_date')
-      self.release_date
+    if respond_to?('announcement_date')
+      announcement_date
+    elsif respond_to?('release_date')
+      release_date
     end
   end
 
-  def has_release_date?
-    self.respond_to?('release_date')
+  def release_date?
+    respond_to?('release_date')
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -3,7 +3,6 @@ class History < ApplicationRecord
   has_one_attached :image
 
   validates :title, presence: true
-  validates :remark, presence: true
   validates :date, presence: true
   validates :image, image: true
 end

--- a/app/views/histories/_disc.html.erb
+++ b/app/views/histories/_disc.html.erb
@@ -12,9 +12,17 @@
       </div>
       <div class="divider divider-horizontal"></div>
       <div class="flex flex-col justify-center w-2/3 md:w-4/5 text-base md:text-lg lg:text-xl">
-        <p class="my-1 text-xs md:text-sm lg:text-base"><%= t("activerecord.attributes.disc.#{disc.production_type}") %></p>
+        <% if disc.has_release_date? %>
+          <p class="my-1 text-xs md:text-sm lg:text-base">
+            <%= t("activerecord.attributes.disc.#{disc.production_type}") %>
+          </p>
+        <% end %>
         <p class="link"><%= link_to disc.title, disc_path(disc) %></p>
-        <p class="my-1"><%= disc.release_date <= Time.zone.today ? "解禁" : "解禁予定" %></p>
+        <% if disc.has_release_date? %>
+          <p class="my-1"><%= disc.release_date <= Time.zone.today ? "解禁" : "解禁予定" %></p>
+        <% else %>
+          <p class="my-1">情報を解禁</p>
+        <% end %>
       </div>
     </div>
   <hr />

--- a/app/views/histories/_disc.html.erb
+++ b/app/views/histories/_disc.html.erb
@@ -1,20 +1,6 @@
 <li>
   <hr />
-    <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
-      <%= I18n.l(disc.release_date, format: "%Y/%m/%d(%a)") %>
-    </div>
-    <div class="timeline-middle">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 20 20"
-        fill="<%= "currentColor" if disc.release_date <= Time.zone.today %>"
-        class="h-5 w-5">
-        <path
-          fill-rule="<%= "evenodd" if disc.release_date <= Time.zone.today %>"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-          clip-rule="evenodd" />
-      </svg>
-    </div>
+    <%= render partial: "timeline_marks", locals: { history: disc, previous_history: previous_history} %>
     <div class="timeline-end timeline-box flex bg-base-300 text-base-content my-3 w-full p-5">
       <div class="my-2 w-1/3 md:w-1/5 items-center justify-center">
         <turbo-frame id="history_disc_<%= disc.id %>" src="/history_discs/<%= disc.id %>" loading="lazy">

--- a/app/views/histories/_disc.html.erb
+++ b/app/views/histories/_disc.html.erb
@@ -12,13 +12,13 @@
       </div>
       <div class="divider divider-horizontal"></div>
       <div class="flex flex-col justify-center w-2/3 md:w-4/5 text-base md:text-lg lg:text-xl">
-        <% if disc.has_release_date? %>
+        <% if disc.release_date? %>
           <p class="my-1 text-xs md:text-sm lg:text-base">
             <%= t("activerecord.attributes.disc.#{disc.production_type}") %>
           </p>
         <% end %>
         <p class="link"><%= link_to disc.title, disc_path(disc) %></p>
-        <% if disc.has_release_date? %>
+        <% if disc.release_date? %>
           <p class="my-1"><%= disc.release_date <= Time.zone.today ? "解禁" : "解禁予定" %></p>
         <% else %>
           <p class="my-1">情報を解禁</p>

--- a/app/views/histories/_disc_timeline_mark.html.erb
+++ b/app/views/histories/_disc_timeline_mark.html.erb
@@ -1,19 +1,19 @@
 <% case previous_history %>
   <% when History, Event %>
-    <% if disc.release_date != previous_history.date %>
+    <% if disc.about_date != previous_history.date %>
       <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
-        <%= I18n.l(disc.release_date, format: "%Y/%m/%d(%a)") %>
+        <%= I18n.l(disc.about_date, format: "%Y/%m/%d(%a)") %>
       </div>
     <% end %>
     <div class="timeline-middle">
-      <% if disc.release_date != previous_history.date %>
+      <% if disc.about_date != previous_history.date %>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          fill="<%= "currentColor" if disc.release_date <= Time.zone.today %>"
+          fill="<%= "currentColor" if disc.about_date <= Time.zone.today %>"
           class="h-5 w-5">
           <path
-            fill-rule="<%= "evenodd" if disc.release_date <= Time.zone.today %>"
+            fill-rule="<%= "evenodd" if disc.about_date <= Time.zone.today %>"
             d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
             clip-rule="evenodd" />
         </svg>
@@ -22,20 +22,20 @@
       <% end %>
     </div>
   <% when Disc %>
-    <% if disc.release_date != previous_history.release_date %>
+    <% if previous_history.date_inspection(disc.about_date) %>
       <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
-        <%= I18n.l(disc.release_date, format: "%Y/%m/%d(%a)") %>
+        <%= I18n.l(disc.about_date, format: "%Y/%m/%d(%a)") %>
       </div>
     <% end %>
     <div class="timeline-middle">
-      <% if disc.release_date != previous_history.release_date %>
+      <% if previous_history.date_inspection(disc.about_date) %>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          fill="<%= "currentColor" if disc.release_date <= Time.zone.today %>"
+          fill="<%= "currentColor" if disc.about_date <= Time.zone.today %>"
           class="h-5 w-5">
           <path
-            fill-rule="<%= "evenodd" if disc.release_date <= Time.zone.today %>"
+            fill-rule="<%= "evenodd" if disc.about_date <= Time.zone.today %>"
             d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
             clip-rule="evenodd" />
         </svg>

--- a/app/views/histories/_disc_timeline_mark.html.erb
+++ b/app/views/histories/_disc_timeline_mark.html.erb
@@ -1,0 +1,46 @@
+<% case previous_history %>
+  <% when History, Event %>
+    <% if disc.release_date != previous_history.date %>
+      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
+        <%= I18n.l(disc.release_date, format: "%Y/%m/%d(%a)") %>
+      </div>
+    <% end %>
+    <div class="timeline-middle">
+      <% if disc.release_date != previous_history.date %>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="<%= "currentColor" if disc.release_date <= Time.zone.today %>"
+          class="h-5 w-5">
+          <path
+            fill-rule="<%= "evenodd" if disc.release_date <= Time.zone.today %>"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+            clip-rule="evenodd" />
+        </svg>
+      <% else %>
+        <div class="w-5"></div>
+      <% end %>
+    </div>
+  <% when Disc %>
+    <% if disc.release_date != previous_history.release_date %>
+      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
+        <%= I18n.l(disc.release_date, format: "%Y/%m/%d(%a)") %>
+      </div>
+    <% end %>
+    <div class="timeline-middle">
+      <% if disc.release_date != previous_history.release_date %>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="<%= "currentColor" if disc.release_date <= Time.zone.today %>"
+          class="h-5 w-5">
+          <path
+            fill-rule="<%= "evenodd" if disc.release_date <= Time.zone.today %>"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+            clip-rule="evenodd" />
+        </svg>
+      <% else %>
+        <div class="w-5"></div>
+      <% end %>
+    </div>
+<% end %>

--- a/app/views/histories/_event.html.erb
+++ b/app/views/histories/_event.html.erb
@@ -1,20 +1,6 @@
 <li>
   <hr />
-    <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
-      <%= I18n.l(event.date, format: "%Y/%m/%d(%a)") %>
-    </div>
-    <div class="timeline-middle">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 20 20"
-        fill="<%= "currentColor" if event.date <= Time.zone.today %>"
-        class="h-5 w-5">
-        <path
-          fill-rule="<%= "evenodd" if event.date <= Time.zone.today %>"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-          clip-rule="evenodd" />
-      </svg>
-    </div>
+    <%= render partial: "timeline_marks", locals: { history: event, previous_history: previous_history} %>
     <div class="timeline-end timeline-box flex bg-base-300 text-base-content my-3 w-full lg:max-h-40 p-5">
       <div class="my-2 w-1/3 md:w-1/5 items-center justify-center">
         <turbo-frame id="history_event_<%= event.id %>" src="/history_events/<%= event.id %>" loading="lazy">

--- a/app/views/histories/_event_timeline_mark.html.erb
+++ b/app/views/histories/_event_timeline_mark.html.erb
@@ -22,13 +22,13 @@
       <% end %>
     </div>
   <% when Disc %>
-    <% if event.date != previous_history.release_date %>
+    <% if previous_history.date_inspection(event.date) %>
       <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
         <%= I18n.l(event.date, format: "%Y/%m/%d(%a)") %>
       </div>
     <% end %>
     <div class="timeline-middle">
-      <% if event.date != previous_history.release_date %>
+      <% if previous_history.date_inspection(event.date) %>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"

--- a/app/views/histories/_event_timeline_mark.html.erb
+++ b/app/views/histories/_event_timeline_mark.html.erb
@@ -1,0 +1,46 @@
+<% case previous_history %>
+  <% when History, Event %>
+    <% if event.date != previous_history.date %>
+      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
+        <%= I18n.l(event.date, format: "%Y/%m/%d(%a)") %>
+      </div>
+    <% end %>
+    <div class="timeline-middle">
+      <% if event.date != previous_history.date %>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="<%= "currentColor" if event.date <= Time.zone.today %>"
+          class="h-5 w-5">
+          <path
+            fill-rule="<%= "evenodd" if event.date <= Time.zone.today %>"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+            clip-rule="evenodd" />
+        </svg>
+      <% else %>
+        <div class="w-5"></div>
+      <% end %>
+    </div>
+  <% when Disc %>
+    <% if event.date != previous_history.release_date %>
+      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
+        <%= I18n.l(event.date, format: "%Y/%m/%d(%a)") %>
+      </div>
+    <% end %>
+    <div class="timeline-middle">
+      <% if event.date != previous_history.release_date %>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="<%= "currentColor" if event.date <= Time.zone.today %>"
+          class="h-5 w-5">
+          <path
+            fill-rule="<%= "evenodd" if event.date <= Time.zone.today %>"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+            clip-rule="evenodd" />
+        </svg>
+      <% else %>
+        <div class="w-5"></div>
+      <% end %>
+    </div>
+<% end %>

--- a/app/views/histories/_form.html.erb
+++ b/app/views/histories/_form.html.erb
@@ -16,5 +16,5 @@
     <%= f.label :image, '画像（任意）' %>
     <%= f.file_field :image, class: "file-input file-input-bordered w-full max-w-xs my-3" %>
   </div>
-    <%= f.submit "登録する", class: "btn btn-primary my-4" %>
+    <%= f.submit "登録する", class: "btn btn-primary my-4", data: { turbo_confirm: "ヒストリーを投稿します！よろしいですか？" } %>
 <% end %>

--- a/app/views/histories/_form.html.erb
+++ b/app/views/histories/_form.html.erb
@@ -9,11 +9,11 @@
     <%= f.text_field :title, placeholder: "(例)🎊MusicStation初出演！🎊", class: "input input-bordered w-full my-3" %>
   </div>
   <div>
-    <%= f.label "説明欄（必須）" %>
+    <%= f.label "説明欄（任意）" %>
     <%= f.text_field :remark, class: "textarea textarea-bordered w-full h-24 my-3", placeholder: "(例)メリバを披露" %>
   </div>
   <div class="flex flex-col">
-    <%= f.label :image, '画像（一枚のみ）' %>
+    <%= f.label :image, '画像（任意）' %>
     <%= f.file_field :image, class: "file-input file-input-bordered w-full max-w-xs my-3" %>
   </div>
     <%= f.submit "登録する", class: "btn btn-primary my-4" %>

--- a/app/views/histories/_histories.html.erb
+++ b/app/views/histories/_histories.html.erb
@@ -3,11 +3,11 @@
     <% @histories.each_with_index do |history, i| %>
       <% case history %>
       <% when Event %>
-        <%= render partial: 'histories/event', locals: { event: history, i: i } %>
+        <%= render partial: 'histories/event', locals: { event: history, previous_history: @histories[i - 1] } %>
       <% when Disc %>
-        <%= render partial: 'histories/disc', locals: { disc: history, i: i } %>
+        <%= render partial: 'histories/disc', locals: { disc: history, previous_history: @histories[i - 1] } %>
       <% when History %>
-        <%= render partial: 'histories/history', locals: { history: history, i: i } %>
+        <%= render partial: 'histories/history', locals: { history: history, previous_history: @histories[i - 1] } %>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/histories/_histories.html.erb
+++ b/app/views/histories/_histories.html.erb
@@ -3,11 +3,11 @@
     <% @histories.each_with_index do |history, i| %>
       <% case history %>
       <% when Event %>
-        <%= render partial: 'histories/event', locals: { event: history, i: i + 1 } %>
+        <%= render partial: 'histories/event', locals: { event: history, i: i } %>
       <% when Disc %>
-        <%= render partial: 'histories/disc', locals: { disc: history, i: i + 1 } %>
+        <%= render partial: 'histories/disc', locals: { disc: history, i: i } %>
       <% when History %>
-        <%= render partial: 'histories/history', locals: { history: history, i: i + 1 } %>
+        <%= render partial: 'histories/history', locals: { history: history, i: i } %>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/histories/_history.html.erb
+++ b/app/views/histories/_history.html.erb
@@ -1,20 +1,6 @@
 <li>
   <hr />
-    <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
-      <%= I18n.l(history.date, format: "%Y/%m/%d(%a)") %>
-    </div>
-    <div class="timeline-middle">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 20 20"
-        fill="<%= "currentColor" if history.date <= Time.zone.today %>"
-        class="h-5 w-5">
-        <path
-          fill-rule="<%= "evenodd" if history.date <= Time.zone.today %>"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-          clip-rule="evenodd" />
-      </svg>
-    </div>
+    <%= render partial: "timeline_marks", locals: { history: history, previous_history: previous_history} %>
     <div class="timeline-end timeline-box flex bg-base-300 text-base-content my-3 w-full lg:max-h-40 p-5">
       <div class="my-2 w-1/3 md:w-1/5 items-center justify-center">
         <turbo-frame id="history_history_<%= history.id %>" src="/history_histories/<%= history.id %>" loading="lazy">

--- a/app/views/histories/_history_timeline_mark.html.erb
+++ b/app/views/histories/_history_timeline_mark.html.erb
@@ -22,13 +22,13 @@
       <% end %>
     </div>
   <% when Disc %>
-    <% if history.date != previous_history.release_date %>
+    <% if previous_history.date_inspection(history.date) %>
       <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
         <%= I18n.l(history.date, format: "%Y/%m/%d(%a)") %>
       </div>
     <% end %>
     <div class="timeline-middle">
-      <% if history.date != previous_history.release_date %>
+      <% if previous_history.date_inspection(history.date) %>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"

--- a/app/views/histories/_history_timeline_mark.html.erb
+++ b/app/views/histories/_history_timeline_mark.html.erb
@@ -1,0 +1,46 @@
+<% case previous_history %>
+  <% when History, Event %>
+    <% if history.date != previous_history.date %>
+      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
+        <%= I18n.l(history.date, format: "%Y/%m/%d(%a)") %>
+      </div>
+    <% end %>
+    <div class="timeline-middle">
+      <% if history.date != previous_history.date %>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="<%= "currentColor" if history.date <= Time.zone.today %>"
+          class="h-5 w-5">
+          <path
+            fill-rule="<%= "evenodd" if history.date <= Time.zone.today %>"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+            clip-rule="evenodd" />
+        </svg>
+      <% else %>
+        <div class="w-5"></div>
+      <% end %>
+    </div>
+  <% when Disc %>
+    <% if history.date != previous_history.release_date %>
+      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
+        <%= I18n.l(history.date, format: "%Y/%m/%d(%a)") %>
+      </div>
+    <% end %>
+    <div class="timeline-middle">
+      <% if history.date != previous_history.release_date %>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="<%= "currentColor" if history.date <= Time.zone.today %>"
+          class="h-5 w-5">
+          <path
+            fill-rule="<%= "evenodd" if history.date <= Time.zone.today %>"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+            clip-rule="evenodd" />
+        </svg>
+      <% else %>
+        <div class="w-5"></div>
+      <% end %>
+    </div>
+<% end %>

--- a/app/views/histories/_timeline_marks.html.erb
+++ b/app/views/histories/_timeline_marks.html.erb
@@ -3,4 +3,6 @@
     <%= render partial: "history_timeline_mark", locals: { history: history, previous_history: previous_history } %>
   <% when Disc %>
     <%= render partial: "disc_timeline_mark", locals: { disc: history, previous_history: previous_history } %>
+  <% when Event %>
+    <%= render partial: "event_timeline_mark", locals: { event: history, previous_history: previous_history } %>
 <% end %>

--- a/app/views/histories/_timeline_marks.html.erb
+++ b/app/views/histories/_timeline_marks.html.erb
@@ -1,0 +1,4 @@
+<% case history %>
+  <% when History %>
+    <%= render partial: "history_timeline_mark", locals: { history: history, previous_history: previous_history } %>
+<% end %>

--- a/app/views/histories/_timeline_marks.html.erb
+++ b/app/views/histories/_timeline_marks.html.erb
@@ -1,4 +1,6 @@
 <% case history %>
   <% when History %>
     <%= render partial: "history_timeline_mark", locals: { history: history, previous_history: previous_history } %>
+  <% when Disc %>
+    <%= render partial: "disc_timeline_mark", locals: { disc: history, previous_history: previous_history } %>
 <% end %>

--- a/db/migrate/20241224112156_change_history_column_to_null.rb
+++ b/db/migrate/20241224112156_change_history_column_to_null.rb
@@ -1,0 +1,5 @@
+class ChangeHistoryColumnToNull < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :histories, :remark, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_20_040813) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_24_112156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -116,7 +116,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_20_040813) do
     t.date "date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "remark", null: false
+    t.text "remark"
   end
 
   create_table "information", force: :cascade do |t|


### PR DESCRIPTION
## 概要
ヒストリー一覧画面に微修正を加えました。

## 加えた変更
* 年表の各要素が、一つ前の要素と同じ日付の場合、日付の表示をスキップ
* Historyモデルの`remark`カラムの`null`を許可
* Discの`release_date`と`announcement_date`の両方を使用する形に変更

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #332 