### PR TITLE
Fix discs#showアクションのエラー修正

### DIFF
--- a/app/views/discs/show.html.erb
+++ b/app/views/discs/show.html.erb
@@ -11,8 +11,12 @@
     </div>
     <div>
       <p>形態：<%= t("activerecord.attributes.disc.#{@disc.production_type}") %></p>
-      <p>解禁日：<%= I18n.l(@disc.announcement_date, format: "%Y/%m/%d(%a)") %></p>
-      <p>発売日：<%= I18n.l(@disc.release_date, format: "%Y/%m/%d(%a)") %></p>
+      <% if @disc.announcement_date.present? %>
+        <p>解禁日：<%= I18n.l(@disc.announcement_date, format: "%Y/%m/%d(%a)") %></p>
+      <% end %>
+      <% if @disc.release_date.present? %>
+        <p>発売日：<%= I18n.l(@disc.release_date, format: "%Y/%m/%d(%a)") %></p>
+      <% end %>
     </div>
   </div>
 


### PR DESCRIPTION
## 概要
discsのshowアクションページ表示時のエラーを修正しました。

## 加えた変更
* `release_date`や`announcement_date`がnilの場合の表示を変更

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
