### PR TITLE
Feat ヒストリーページのソート機能実装

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -1,7 +1,7 @@
 class HistoriesController < ApplicationController
   def index
     params_inspection
-    p params
+    Rails.logger.debug params
     @histories = []
     add_to_histories(:events, Event)
     if params[:discs] == '1'
@@ -69,9 +69,9 @@ class HistoriesController < ApplicationController
 
   def params_inspection
     valid_values = %w[0 1]
-    params[:events] = "1" if (params[:events]).nil?
-    params[:discs] = "1" if (params[:discs]).nil?
-    params[:histories] = "1" if (params[:histories]).nil?
+    params[:events] = '1' if params[:events].nil?
+    params[:discs] = '1' if params[:discs].nil?
+    params[:histories] = '1' if params[:histories].nil?
     params[:events] = valid_values.include?(params[:events]) ? params[:events] : '0'
     params[:discs] = valid_values.include?(params[:discs]) ? params[:discs] : '0'
     params[:histories] = valid_values.include?(params[:histories]) ? params[:histories] : '0'
@@ -79,8 +79,9 @@ class HistoriesController < ApplicationController
 
   def add_to_histories(param_key, model)
     return if params[param_key] == '0'
-    if params[param_key] == '1'
-      @histories << model.all
-    end
+
+    return unless params[param_key] == '1'
+
+    @histories << model.all
   end
 end

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -1,7 +1,6 @@
 class HistoriesController < ApplicationController
   def index
     params_inspection
-    Rails.logger.debug params
     @histories = []
     add_to_histories(:events, Event)
     if params[:discs] == '1'

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -1,5 +1,6 @@
 class HistoriesController < ApplicationController
   def index
+    params_inspection
     @histories = []
     @histories << Event.all if params[:events] == "1"
     @histories << Disc.where.not(release_date: nil).select(:title, :release_date, :production_type, :id) if params[:discs] == "1"
@@ -59,5 +60,12 @@ class HistoriesController < ApplicationController
 
   def history_params
     params.require(:history).permit(:title, :remark, :date, :image).merge(user_id: current_user.id)
+  end
+
+  def params_inspection
+    valid_values = ["0", "1"]
+    params[:events] = valid_values.include?(params[:events]) ? params[:events] : nil
+    params[:discs] = valid_values.include?(params[:discs]) ? params[:discs] : nil
+    params[:histories] = valid_values.include?(params[:histories]) ? params[:histories] : nil
   end
 end

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -1,10 +1,12 @@
 class HistoriesController < ApplicationController
   def index
     @histories = []
-    @histories << Event.all
-    @histories << Disc.where.not(release_date: nil).select(:title, :release_date, :production_type, :id)
-    @histories << Disc.where.not(announcement_date: nil).select(:title, :announcement_date, :production_type, :id)
-    @histories << History.all
+    @histories << Event.all if params[:events] == "1"
+    @histories << Disc.where.not(release_date: nil).select(:title, :release_date, :production_type, :id) if params[:discs] == "1"
+    @histories << Disc.where.not(announcement_date: nil).select(:title, :announcement_date, :production_type, :id) if params[:discs] == "1"
+    @histories << History.all if params[:histories] == "1"
+
+    return if @histories.empty?
     @histories.flatten!.sort_by! do |history|
       if history.respond_to?('date')
         history.date

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -1,13 +1,18 @@
 class HistoriesController < ApplicationController
   def index
     params_inspection
+    p params
     @histories = []
-    @histories << Event.all if params[:events] == "1"
-    @histories << Disc.where.not(release_date: nil).select(:title, :release_date, :production_type, :id) if params[:discs] == "1"
-    @histories << Disc.where.not(announcement_date: nil).select(:title, :announcement_date, :production_type, :id) if params[:discs] == "1"
-    @histories << History.all if params[:histories] == "1"
+    add_to_histories(:events, Event)
+    if params[:discs] == '1'
+      @histories << Disc.where.not(release_date: nil).select(:title, :release_date, :production_type, :id)
+      @histories << Disc.where.not(announcement_date: nil).select(:title, :announcement_date, :production_type,
+                                                                  :id)
+    end
+    add_to_histories(:histories, History)
 
     return if @histories.empty?
+
     @histories.flatten!.sort_by! do |history|
       if history.respond_to?('date')
         history.date
@@ -63,9 +68,19 @@ class HistoriesController < ApplicationController
   end
 
   def params_inspection
-    valid_values = ["0", "1"]
-    params[:events] = valid_values.include?(params[:events]) ? params[:events] : nil
-    params[:discs] = valid_values.include?(params[:discs]) ? params[:discs] : nil
-    params[:histories] = valid_values.include?(params[:histories]) ? params[:histories] : nil
+    valid_values = %w[0 1]
+    params[:events] = "1" if (params[:events]).nil?
+    params[:discs] = "1" if (params[:discs]).nil?
+    params[:histories] = "1" if (params[:histories]).nil?
+    params[:events] = valid_values.include?(params[:events]) ? params[:events] : '0'
+    params[:discs] = valid_values.include?(params[:discs]) ? params[:discs] : '0'
+    params[:histories] = valid_values.include?(params[:histories]) ? params[:histories] : '0'
+  end
+
+  def add_to_histories(param_key, model)
+    return if params[param_key] == '0'
+    if params[param_key] == '1'
+      @histories << model.all
+    end
   end
 end

--- a/app/views/histories/_histories.html.erb
+++ b/app/views/histories/_histories.html.erb
@@ -1,5 +1,11 @@
 <div class="">
   <ul class="timeline timeline-vertical timeline-compact">
+    <% if @histories.empty? %>
+      <div class="my-3">
+        <p>表示するヒストリーがありません🤥</p>
+        <p>絞り込みから表示するカテゴリーを選択してください。</p>
+      </div>
+    <% end %>
     <% @histories.each_with_index do |history, i| %>
       <% case history %>
       <% when Event %>
@@ -13,4 +19,4 @@
   </ul>
 </div>
 
-<%= paginate @histories %>
+<%= paginate @histories unless @histories.empty? %>

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -3,8 +3,12 @@
     <%= title "ヒストリー一覧" %>
   </h1>
 
-  <div class="flex flex-row-reverse">
+  <div class="grid justify-items-end">
     <%= link_to "ヒストリー登録", new_history_path, class: "btn btn-primary mb-5" %>
+  </div>
+
+  <div class="grid justify-items-end">
+    <%= render partial: "histories/modals/sort_form_modal" %>
   </div>
 
   <%= render partial: 'histories' %>

--- a/app/views/histories/modals/_sort_form_modal.html.erb
+++ b/app/views/histories/modals/_sort_form_modal.html.erb
@@ -1,0 +1,14 @@
+<div data-controller="dialog" data-action="click->dialog#backdropClose">
+  <dialog data-dialog-target="dialog" class="bg-neutral-200 p-5 text-slate-900 rounded-lg">
+    <div class="grid justify-items-end">
+      <button type="button" data-action="dialog#close" autofocus><i class="fa-regular fa-circle-xmark mr-1"></i></button>
+    </div>
+    <div class="mb-3 leading-8">
+
+    </div>
+  </dialog>
+  <button type="button" data-action="dialog#open" class="flex items-center">
+    <i class="fa-solid fa-filter mx-1"></i>
+    <p>絞り込み</p>
+  </button>
+</div>

--- a/app/views/histories/modals/_sort_form_modal.html.erb
+++ b/app/views/histories/modals/_sort_form_modal.html.erb
@@ -21,7 +21,7 @@
           </div>
         </div>
 
-        <%= f.submit "絞り込む", class: "btn" %>
+        <%= f.submit "絞り込む", name: '', class: "btn" %>
       <% end %>
     </div>
   </dialog>

--- a/app/views/histories/modals/_sort_form_modal.html.erb
+++ b/app/views/histories/modals/_sort_form_modal.html.erb
@@ -4,7 +4,25 @@
       <button type="button" data-action="dialog#close" autofocus><i class="fa-regular fa-circle-xmark mr-1"></i></button>
     </div>
     <div class="mb-3 leading-8">
+      <h1 class="my-3 text-lg md:text-xl">ヒストリー絞り込み</h1>
+      <%= form_with url: "/histories", method: :get do |f| %>
+        <div class="flex flex-col mb-5">
+          <div class="flex">
+            <%= f.checkbox :events %>
+            <%= f.label "イベント情報" %>
+          </div>
+          <div class="flex">
+            <%= f.checkbox :discs %>
+            <%= f.label "ディスコグラフィー関連" %>
+          </div>
+          <div class="flex">
+            <%= f.checkbox :histories %>
+            <%= f.label "その他のヒストリー" %>
+          </div>
+        </div>
 
+        <%= f.submit "絞り込む", class: "btn" %>
+      <% end %>
     </div>
   </dialog>
   <button type="button" data-action="dialog#open" class="flex items-center">

--- a/app/views/histories/modals/_sort_form_modal.html.erb
+++ b/app/views/histories/modals/_sort_form_modal.html.erb
@@ -8,15 +8,15 @@
       <%= form_with url: "/histories", method: :get do |f| %>
         <div class="flex flex-col mb-5">
           <div class="flex">
-            <%= f.checkbox :events %>
+            <%= f.checkbox :events, class: "mx-1" %>
             <%= f.label "イベント情報" %>
           </div>
           <div class="flex">
-            <%= f.checkbox :discs %>
+            <%= f.checkbox :discs, class: "mx-1" %>
             <%= f.label "ディスコグラフィー関連" %>
           </div>
           <div class="flex">
-            <%= f.checkbox :histories %>
+            <%= f.checkbox :histories, class: "mx-1" %>
             <%= f.label "その他のヒストリー" %>
           </div>
         </div>


### PR DESCRIPTION
## 概要
ヒストリー一覧ページに、カテゴリーごとの絞り込み機能を実装しました。

## 加えた変更
* http://localhost:3000/histories（絞り込み検索をしていない場合）では、すべてのカテゴリーが表示されます。
  <img width="337" alt="スクリーンショット 2024-12-26 15 48 39" src="https://github.com/user-attachments/assets/1dbeb1f1-bd4d-4ca8-8963-0de65a0b235a" />
* 各カテゴリーで絞り込みを行った場合、選択されたカテゴリーだけが表示されます。
  [![Image from Gyazo](https://i.gyazo.com/22dbaa3d1b2b7edb1f6a69bcfc7b4d39.gif)](https://gyazo.com/22dbaa3d1b2b7edb1f6a69bcfc7b4d39)
* カテゴリーを何も選択せずに絞り込みボタンを押すと、検索結果を0研にします。<img width="358" alt="スクリーンショット 2024-12-26 15 50 41" src="https://github.com/user-attachments/assets/0a97c6b8-e97e-4723-97ed-babe96ee5e22" />


## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #231 