### PR TITLE
Feat ヒストリーレコードへのいいね実装

### DIFF
--- a/app/controllers/histories/likes_controller.rb
+++ b/app/controllers/histories/likes_controller.rb
@@ -1,6 +1,6 @@
 class Histories::LikesController < ApplicationController
   def create
-    @history = History.find(params[:history_id])
+    @history = History.preload(:likes).find(params[:history_id])
     likes = @history.likes.new(user_id: current_user.id)
     likes.save
     respond_to do |format|

--- a/app/controllers/histories/likes_controller.rb
+++ b/app/controllers/histories/likes_controller.rb
@@ -1,14 +1,19 @@
 class Histories::LikesController < ApplicationController
   def create
-    @history = History.preload(:likes).find(params[:history_id])
+    @history = History.find(params[:history_id])
     like = @history.likes.new(user_id: current_user.id)
     like.save
-    obj = @history
     respond_to do |format|
-      format.turbo_stream { render 'likes/create', locals: { obj: @history } }
+      format.turbo_stream { render 'likes/create', locals: { obj: @history, history: @history } }
     end
   end
 
   def destroy
+    @history = History.find(params[:history_id])
+    like = @history.likes.find_by(user_id: current_user.id, likable_id: @history.id)
+    like.destroy
+    respond_to do |format|
+      format.turbo_stream { render 'likes/destroy', locals: { obj: @history, history: @history } }
+    end
   end
 end

--- a/app/controllers/histories/likes_controller.rb
+++ b/app/controllers/histories/likes_controller.rb
@@ -1,10 +1,11 @@
 class Histories::LikesController < ApplicationController
   def create
     @history = History.preload(:likes).find(params[:history_id])
-    likes = @history.likes.new(user_id: current_user.id)
-    likes.save
+    like = @history.likes.new(user_id: current_user.id)
+    like.save
+    obj = @history
     respond_to do |format|
-      format.turbo_stream { render 'likes/create' }
+      format.turbo_stream { render 'likes/create', locals: { obj: @history } }
     end
   end
 

--- a/app/controllers/histories/likes_controller.rb
+++ b/app/controllers/histories/likes_controller.rb
@@ -1,9 +1,11 @@
 class Histories::LikesController < ApplicationController
   def create
-    history = History.find(params[:history_id])
-    likes = history.likes.new(user_id: current_user.id)
+    @history = History.find(params[:history_id])
+    likes = @history.likes.new(user_id: current_user.id)
     likes.save
-    redirect_to histories_path
+    respond_to do |format|
+      format.turbo_stream { render 'likes/create' }
+    end
   end
 
   def destroy

--- a/app/controllers/histories/likes_controller.rb
+++ b/app/controllers/histories/likes_controller.rb
@@ -1,0 +1,11 @@
+class Histories::LikesController < ApplicationController
+  def create
+    history = History.find(params[:history_id])
+    likes = history.likes.new(user_id: current_user.id)
+    likes.save
+    redirect_to histories_path
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,7 @@
+class LikesController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/decorators/like_decorator.rb
+++ b/app/decorators/like_decorator.rb
@@ -1,0 +1,13 @@
+class LikeDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/decorators/like_decorator.rb
+++ b/app/decorators/like_decorator.rb
@@ -9,5 +9,4 @@ class LikeDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -2,6 +2,7 @@ class History < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_many :informations, as: :reportable, dependent: :destroy
+  has_many :likes, as: :likable, dependent: :destroy
 
   validates :title, presence: true
   validates :date, presence: true

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -9,6 +9,6 @@ class History < ApplicationRecord
   validates :image, image: true
 
   def liked_by?(user)
-    likes.where(user_id: user.id).exists?
+    likes.exists?(user_id: user.id)
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -7,4 +7,8 @@ class History < ApplicationRecord
   validates :title, presence: true
   validates :date, presence: true
   validates :image, image: true
+
+  def liked_by?(user)
+    likes.where(user_id: user.id).exists?
+  end
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :likable, polymorphic: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
   has_many :bookmark_events, through: :event_bookmarks, source: :event
   has_many :informations, as: :reportable, dependent: :destroy
   has_many :histories, dependent: :destroy
+  has_many :likes, as: :likable, dependent: :destroy
 
   # Twitter認証ログイン用
   # ユーザーの情報があれば探し、無ければ作成する

--- a/app/views/histories/_history.html.erb
+++ b/app/views/histories/_history.html.erb
@@ -19,7 +19,7 @@
         <% end %>
         <p class="my-2 text-xs md:text-sm lg:text-base"><%= history.remark.truncate(30) %></p>
         <div class="flex mt-3">
-          <%= render partial: "likes/likes", locals: { history: history } %>
+          <%= render partial: "likes/likes", locals: { history: history, likes: history.likes, like_url: history_likes_path(history_id: history.id) } %>
           <% if history.user == current_user %>
             <%= link_to edit_history_path(history.id) do %>
               <i class="fa-solid fa-pen-to-square mr-3"></i>

--- a/app/views/histories/_history.html.erb
+++ b/app/views/histories/_history.html.erb
@@ -19,6 +19,7 @@
         <% end %>
         <p class="my-2 text-xs md:text-sm lg:text-base"><%= history.remark.truncate(30) %></p>
         <div class="flex mt-3">
+          <%= render partial: "likes/likes", locals: { history: history } %>
           <% if history.user == current_user %>
             <%= link_to edit_history_path(history.id) do %>
               <i class="fa-solid fa-pen-to-square mr-3"></i>

--- a/app/views/histories/show.html.erb
+++ b/app/views/histories/show.html.erb
@@ -21,6 +21,7 @@
       </turbo-frame>
     </div>
       <div class="flex justify-end mt-3">
+        <%= render partial: "likes/likes", locals: { history: @history, likes: @history.likes, like_url: history_likes_path(history_id: @history.id) } %>
         <% if @history.user == current_user %>
           <%= link_to edit_history_path(@history.id) do %>
             <i class="fa-solid fa-pen-to-square mr-3"></i>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,0 +1,4 @@
+<div class="flex mr-3 items-center">
+  <i class="fa-regular fa-heart mr-1"></i>
+  <p><%= history.likes.length %></p>
+</div>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,4 +1,4 @@
-<div class="flex mr-3 items-center">
+<%= link_to like_url, data: { "turbo-method": :post }, class: "flex mr-3 items-center" do %>
   <i class="fa-regular fa-heart mr-1"></i>
-  <p><%= history.likes.length %></p>
-</div>
+  <p><%= likes.length %></p>
+<% end %>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "likes" do %>
+<%= turbo_frame_tag "like_#{obj.class}_#{obj.id}" do %>
   <%= link_to like_url, data: { "turbo-method": :post }, class: "flex mr-3 items-center" do %>
     <i class="fa-regular fa-heart mr-1"></i>
     <p><%= likes.length %></p>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,4 +1,6 @@
-<%= link_to like_url, data: { "turbo-method": :post }, class: "flex mr-3 items-center" do %>
-  <i class="fa-regular fa-heart mr-1"></i>
-  <p><%= likes.length %></p>
+<%= turbo_frame_tag "likes" do %>
+  <%= link_to like_url, data: { "turbo-method": :post }, class: "flex mr-3 items-center" do %>
+    <i class="fa-regular fa-heart mr-1"></i>
+    <p><%= likes.length %></p>
+  <% end %>
 <% end %>

--- a/app/views/likes/_likes.html.erb
+++ b/app/views/likes/_likes.html.erb
@@ -1,5 +1,5 @@
 <% if history.liked_by?(current_user) %>
   <%= render partial: "likes/unlike", locals: { likes: likes } %>
 <% else %>
-  <%= render partial: "likes/like", locals: { likes: likes, like_url: like_url } %>
+  <%= render partial: "likes/like", locals: { likes: likes, like_url: like_url, obj: history } %>
 <% end %>

--- a/app/views/likes/_likes.html.erb
+++ b/app/views/likes/_likes.html.erb
@@ -1,5 +1,5 @@
 <% if history.liked_by?(current_user) %>
-  <%= render partial: "likes/unlike", locals: { likes: likes } %>
+  <%= render partial: "likes/unlike", locals: { likes: likes, like_url: like_url, obj: history } %>
 <% else %>
   <%= render partial: "likes/like", locals: { likes: likes, like_url: like_url, obj: history } %>
 <% end %>

--- a/app/views/likes/_likes.html.erb
+++ b/app/views/likes/_likes.html.erb
@@ -1,0 +1,5 @@
+<% if history.liked_by?(current_user) %>
+  <%= render partial: "likes/unlike", locals: { history: history } %>
+<% else %>
+  <%= render partial: "likes/like", locals: { history: history } %>
+<% end %>

--- a/app/views/likes/_likes.html.erb
+++ b/app/views/likes/_likes.html.erb
@@ -1,5 +1,5 @@
 <% if history.liked_by?(current_user) %>
-  <%= render partial: "likes/unlike", locals: { history: history } %>
+  <%= render partial: "likes/unlike", locals: { likes: likes } %>
 <% else %>
   <%= render partial: "likes/like", locals: { likes: likes, like_url: like_url } %>
 <% end %>

--- a/app/views/likes/_likes.html.erb
+++ b/app/views/likes/_likes.html.erb
@@ -1,5 +1,5 @@
 <% if history.liked_by?(current_user) %>
   <%= render partial: "likes/unlike", locals: { history: history } %>
 <% else %>
-  <%= render partial: "likes/like", locals: { history: history } %>
+  <%= render partial: "likes/like", locals: { likes: likes, like_url: like_url } %>
 <% end %>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -1,0 +1,4 @@
+<div class="flex mr-3 items-center">
+  <i class="fa-regular fa-heart mr-1"></i>
+  <p><%= history.likes.length %></p>
+</div>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -1,4 +1,4 @@
 <div class="flex mr-3 items-center">
   <i class="fa-solid fa-heart mr-1"></i>
-  <p><%= history.likes.length %></p>
+  <p><%= likes.length %></p>
 </div>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -1,4 +1,4 @@
 <div class="flex mr-3 items-center">
-  <i class="fa-regular fa-heart mr-1"></i>
+  <i class="fa-solid fa-heart mr-1"></i>
   <p><%= history.likes.length %></p>
 </div>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -1,4 +1,6 @@
-<div class="flex mr-3 items-center">
-  <i class="fa-solid fa-heart mr-1"></i>
-  <p><%= likes.length %></p>
-</div>
+<%= turbo_frame_tag "unlike_#{obj.class}_#{obj.id}" do %>
+  <%= link_to like_url, data: { "turbo-method": :delete }, class: "flex mr-3 items-center" do %>
+    <i class="fa-solid fa-heart mr-1"></i>
+    <p><%= likes.length %></p>
+  <% end %>
+<% end %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace "like_#{obj.class}_#{obj.id}" do %>
-  <%= render partial: "likes/unlike", locals: { likes: @history.likes } %>
+  <%= render partial: "likes/unlike", locals: { likes: @history.likes, obj: obj, like_url: history_likes_path(history_id: history.id) } %>
 <% end %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "likes" do %>
+  <%= render partial: "likes/unlike", locals: { likes: @history.likes } %>
+<% end %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace "likes" do %>
+<%= turbo_stream.replace "like_#{obj.class}_#{obj.id}" do %>
   <%= render partial: "likes/unlike", locals: { likes: @history.likes } %>
 <% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "unlike_#{obj.class}_#{obj.id}" do %>
+  <%= render partial: "likes/like", locals: { likes: @history.likes, obj: obj, like_url: history_likes_path(history_id: history.id) } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   resources :histories, only: [:index, :new, :create, :show, :destroy, :edit, :update] do
     post "image/destroy" => "images#history_image_destroy"
     resources :informations, only: [:create], module: :histories
+    resource :likes, only: [:create, :destroy], module: :histories
   end
 
   resources :discs, only: [:show] do

--- a/db/migrate/20241227140739_create_likes.rb
+++ b/db/migrate/20241227140739_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :likes do |t|
+      t.integer :user_id, null: false
+      t.references :likable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_25_021649) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_27_140739) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -127,6 +127,15 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_25_021649) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["reportable_type", "reportable_id"], name: "index_information_on_reportable"
+  end
+
+  create_table "likes", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "likable_type", null: false
+    t.bigint "likable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["likable_type", "likable_id"], name: "index_likes_on_likable"
   end
 
   create_table "likes_on_event_informations", force: :cascade do |t|


### PR DESCRIPTION
## 概要
各ヒストリーレコードへのいいね・いいね解除を実装しました。

## 加えた変更
* [![Image from Gyazo](https://i.gyazo.com/5101bad09bb5f2987b7fa33e0704583d.gif)](https://gyazo.com/5101bad09bb5f2987b7fa33e0704583d)
  上記動画のように、各レコードにいいねを押す・外すことができるようになりました。

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #237 
