### PR TITLE
Feat ディスコグラフィー管理画面作成

### DIFF
--- a/app/admin/disc_contents.rb
+++ b/app/admin/disc_contents.rb
@@ -1,0 +1,2 @@
+ActiveAdmin.register DiscContent do
+end

--- a/app/admin/disc_contents.rb
+++ b/app/admin/disc_contents.rb
@@ -1,2 +1,13 @@
 ActiveAdmin.register DiscContent do
+  permit_params :disc_version_id, :event_id, :content_type
+
+  form do |f|
+    f.inputs do
+      f.input :disc_version_id
+      f.input :content_type
+      f.input :event
+    end
+
+    f.actions
+  end
 end

--- a/app/admin/disc_items.rb
+++ b/app/admin/disc_items.rb
@@ -1,0 +1,15 @@
+ActiveAdmin.register DiscItem do
+  permit_params :disc_content_id, :position, :song_id, :title, :is_arranged
+
+  form do |f|
+    f.inputs do
+      f.input :disc_content_id
+      f.input :position
+      f.input :song
+      f.input :title
+      f.input :is_arranged
+    end
+
+    f.actions
+  end
+end

--- a/app/admin/disc_versions.rb
+++ b/app/admin/disc_versions.rb
@@ -1,18 +1,18 @@
 ActiveAdmin.register DiscVersion do
-
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :disc_id, :version, :price
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:disc_id, :version, :price]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
+  permit_params :disc_id, :version, :price, :jacket, :remove_jacket
   remove_filter :jacket_attachment, :jacket_blob
+
+  form do |f|
+    f.inputs do
+      f.input :disc
+      f.input :version
+      f.input :price
+      f.input :jacket, as: :file, hint: f.object.jacket.present? ? image_tag(f.object.jacket) : nil
+      if f.object.jacket.present?
+        f.input :remove_jacket, as: :boolean, required: :false, label: '画像を削除する'
+      end
+    end
+
+    f.actions
+  end
 end

--- a/app/admin/disc_versions.rb
+++ b/app/admin/disc_versions.rb
@@ -14,5 +14,5 @@ ActiveAdmin.register DiscVersion do
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
   # end
-  
+  remove_filter :jacket_attachment, :jacket_blob
 end

--- a/app/admin/disc_versions.rb
+++ b/app/admin/disc_versions.rb
@@ -8,9 +8,7 @@ ActiveAdmin.register DiscVersion do
       f.input :version
       f.input :price
       f.input :jacket, as: :file, hint: f.object.jacket.present? ? image_tag(f.object.jacket) : nil
-      if f.object.jacket.present?
-        f.input :remove_jacket, as: :boolean, required: :false, label: '画像を削除する'
-      end
+      f.input :remove_jacket, as: :boolean, required: false, label: '画像を削除する' if f.object.jacket.present?
     end
 
     f.actions

--- a/app/admin/disc_versions.rb
+++ b/app/admin/disc_versions.rb
@@ -1,0 +1,18 @@
+ActiveAdmin.register DiscVersion do
+
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :disc_id, :version, :price
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:disc_id, :version, :price]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+  
+end

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -1,18 +1,3 @@
 ActiveAdmin.register Disc do
-
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:title, :title_ruby, :announcement_date, :release_date, :production_type]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
-  
+  permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type
 end

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -1,0 +1,18 @@
+ActiveAdmin.register Disc do
+
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:title, :title_ruby, :announcement_date, :release_date, :production_type]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+  
+end

--- a/app/admin/songs.rb
+++ b/app/admin/songs.rb
@@ -19,5 +19,5 @@ ActiveAdmin.register Song do
   remove_filter :jk_attachment
   remove_filter :jk_blob
   remove_filter :youtube_link
-  permit_params :name, :name_kana_ruby, :name_hiragana_ruby, :announcement_date
+  permit_params :name, :name_kana_ruby, :name_hiragana_ruby, :announcement_date, :youtube_link
 end

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -29,4 +29,12 @@ class Disc < ApplicationRecord
   def release_date?
     respond_to?('release_date')
   end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["disc_versions", "informations", "link_contents"]
+  end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["announcement_date", "created_at", "id", "id_value", "production_type", "release_date", "title", "title_ruby", "updated_at"]
+  end
 end

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -30,11 +30,11 @@ class Disc < ApplicationRecord
     respond_to?('release_date')
   end
 
-  def self.ransackable_associations(auth_object = nil)
-    ["disc_versions", "informations", "link_contents"]
+  def self.ransackable_associations(_auth_object = nil)
+    %w[disc_versions informations link_contents]
   end
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["announcement_date", "created_at", "id", "id_value", "production_type", "release_date", "title", "title_ruby", "updated_at"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[announcement_date created_at id id_value production_type release_date title title_ruby updated_at]
   end
 end

--- a/app/models/disc_content.rb
+++ b/app/models/disc_content.rb
@@ -10,4 +10,8 @@ class DiscContent < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["content_type", "created_at", "disc_version_id", "event_id", "id", "id_value", "updated_at"]
   end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["disc_items", "disc_version", "event"]
+  end
 end

--- a/app/models/disc_content.rb
+++ b/app/models/disc_content.rb
@@ -6,4 +6,8 @@ class DiscContent < ApplicationRecord
   validates :content_type, presence: true
 
   enum :content_type, { songs: 0, events: 1, others: 2 }
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["content_type", "created_at", "disc_version_id", "event_id", "id", "id_value", "updated_at"]
+  end
 end

--- a/app/models/disc_content.rb
+++ b/app/models/disc_content.rb
@@ -7,11 +7,11 @@ class DiscContent < ApplicationRecord
 
   enum :content_type, { songs: 0, events: 1, others: 2 }
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["content_type", "created_at", "disc_version_id", "event_id", "id", "id_value", "updated_at"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[content_type created_at disc_version_id event_id id id_value updated_at]
   end
 
-  def self.ransackable_associations(auth_object = nil)
-    ["disc_items", "disc_version", "event"]
+  def self.ransackable_associations(_auth_object = nil)
+    %w[disc_items disc_version event]
   end
 end

--- a/app/models/disc_item.rb
+++ b/app/models/disc_item.rb
@@ -12,11 +12,11 @@ class DiscItem < ApplicationRecord
     nil if song_id.present? ^ title.present?
   end
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["created_at", "disc_content_id", "id", "id_value", "is_arranged", "position", "song_id", "title", "updated_at"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at disc_content_id id id_value is_arranged position song_id title updated_at]
   end
 
-  def self.ransackable_associations(auth_object = nil)
-    ["disc_content", "song"]
+  def self.ransackable_associations(_auth_object = nil)
+    %w[disc_content song]
   end
 end

--- a/app/models/disc_item.rb
+++ b/app/models/disc_item.rb
@@ -11,4 +11,8 @@ class DiscItem < ApplicationRecord
   def required_either_song_or_title
     nil if song_id.present? ^ title.present?
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "disc_content_id", "id", "id_value", "is_arranged", "position", "song_id", "title", "updated_at"]
+  end
 end

--- a/app/models/disc_item.rb
+++ b/app/models/disc_item.rb
@@ -15,4 +15,8 @@ class DiscItem < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "disc_content_id", "id", "id_value", "is_arranged", "position", "song_id", "title", "updated_at"]
   end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["disc_content", "song"]
+  end
 end

--- a/app/models/disc_item.rb
+++ b/app/models/disc_item.rb
@@ -6,17 +6,17 @@ class DiscItem < ApplicationRecord
   validates :is_arranged, inclusion: { in: [true, false] }
   validate :required_either_song_or_title
 
-  private
-
-  def required_either_song_or_title
-    nil if song_id.present? ^ title.present?
-  end
-
   def self.ransackable_attributes(_auth_object = nil)
     %w[created_at disc_content_id id id_value is_arranged position song_id title updated_at]
   end
 
   def self.ransackable_associations(_auth_object = nil)
     %w[disc_content song]
+  end
+
+  private
+
+  def required_either_song_or_title
+    nil if song_id.present? ^ title.present?
   end
 end

--- a/app/models/disc_version.rb
+++ b/app/models/disc_version.rb
@@ -6,4 +6,8 @@ class DiscVersion < ApplicationRecord
   validates :version, presence: true
 
   enum :version, { streaming: 0, normal: 1, first_press_limited: 2, limited_product_edition: 3, limited_time_edition: 4 }
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "disc_id", "id", "id_value", "price", "updated_at", "version"]
+  end
 end

--- a/app/models/disc_version.rb
+++ b/app/models/disc_version.rb
@@ -14,4 +14,13 @@ class DiscVersion < ApplicationRecord
   def self.ransackable_associations(auth_object = nil)
     ["disc", "disc_contents", "jacket_attachment", "jacket_blob"]
   end
+
+  def remove_jacket
+    @remove_jacket || false
+  end
+
+  def remove_jacket=(value)
+    attribute_will_change!('remove_jacket') if remove_jacket != value
+    @remove_jacket = value
+  end
 end

--- a/app/models/disc_version.rb
+++ b/app/models/disc_version.rb
@@ -10,4 +10,8 @@ class DiscVersion < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "disc_id", "id", "id_value", "price", "updated_at", "version"]
   end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["disc", "disc_contents", "jacket_attachment", "jacket_blob"]
+  end
 end

--- a/app/models/disc_version.rb
+++ b/app/models/disc_version.rb
@@ -7,12 +7,12 @@ class DiscVersion < ApplicationRecord
 
   enum :version, { streaming: 0, normal: 1, first_press_limited: 2, limited_product_edition: 3, limited_time_edition: 4 }
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["created_at", "disc_id", "id", "id_value", "price", "updated_at", "version"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at disc_id id id_value price updated_at version]
   end
 
-  def self.ransackable_associations(auth_object = nil)
-    ["disc", "disc_contents", "jacket_attachment", "jacket_blob"]
+  def self.ransackable_associations(_auth_object = nil)
+    %w[disc disc_contents jacket_attachment jacket_blob]
   end
 
   def remove_jacket

--- a/app/models/information.rb
+++ b/app/models/information.rb
@@ -9,4 +9,8 @@ class Information < ApplicationRecord
   def liked_by?(user)
     likes_on_informations.exists?(user_id: user.id)
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["body", "created_at", "id", "id_value", "reportable_id", "reportable_type", "updated_at", "user_id"]
+  end
 end

--- a/app/models/information.rb
+++ b/app/models/information.rb
@@ -10,7 +10,7 @@ class Information < ApplicationRecord
     likes_on_informations.exists?(user_id: user.id)
   end
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["body", "created_at", "id", "id_value", "reportable_id", "reportable_type", "updated_at", "user_id"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[body created_at id id_value reportable_id reportable_type updated_at user_id]
   end
 end


### PR DESCRIPTION
## 概要
ディスコグラフィーの管理画面を作成しました。

## 加えた変更
* DiscのCRUDページ作成
* DiscVersionのCRUDページ作成
* DiscContentのCRUDページ作成
* DiscItemのCRUDページ作成

## 加えなかった変更
* Disc登録時、DiscContent登録時に、その子要素であるDiscVersionやDiscItemの登録を行えるようにすべきですが、未着手です。別ブランチで作業します。

## 影響範囲

## 関連Issue
* close #232 
* #359 