### PR TITLE
Fix Disc関連の情報一括登録

### DIFF
--- a/app/admin/disc_contents.rb
+++ b/app/admin/disc_contents.rb
@@ -1,13 +1,12 @@
 ActiveAdmin.register DiscContent do
-  permit_params :disc_version_id, :event_id, :content_type, disc_items_attributes: [:id, :disc_content_id, :position, :song_id, :title, :is_arranged, :_destroy]
+  permit_params :disc_version_id, :event_id, :content_type,
+                disc_items_attributes: [:id, :disc_content_id, :position, :song_id, :title, :is_arranged, :_destroy]
 
   index do
     id_column
     column :disc_version
     column :content_type
     column :event
-    column :created_at
-    column :updated_at
     actions
   end
 
@@ -19,7 +18,7 @@ ActiveAdmin.register DiscContent do
     end
 
     f.inputs do
-      f.has_many :disc_items, allow_destroy: true do|t|
+      f.has_many :disc_items, allow_destroy: true do |t|
         t.input :position
         t.input :title
         t.input :song

--- a/app/admin/disc_contents.rb
+++ b/app/admin/disc_contents.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register DiscContent do
-  permit_params :disc_version_id, :event_id, :content_type
+  permit_params :disc_version_id, :event_id, :content_type, disc_items_attributes: [:id, :disc_content_id, :position, :song_id, :title, :is_arranged, :_destroy]
 
   index do
     id_column
@@ -13,9 +13,18 @@ ActiveAdmin.register DiscContent do
 
   form do |f|
     f.inputs do
-      f.input :disc_version_id
+      f.input :disc_version
+      f.input :event_id
       f.input :content_type
-      f.input :event
+    end
+
+    f.inputs do
+      f.has_many :disc_items, allow_destroy: true do|t|
+        t.input :position
+        t.input :title
+        t.input :song
+        t.input :is_arranged
+      end
     end
 
     f.actions

--- a/app/admin/disc_contents.rb
+++ b/app/admin/disc_contents.rb
@@ -1,6 +1,16 @@
 ActiveAdmin.register DiscContent do
   permit_params :disc_version_id, :event_id, :content_type
 
+  index do
+    id_column
+    column :disc_version
+    column :content_type
+    column :event
+    column :created_at
+    column :updated_at
+    actions
+  end
+
   form do |f|
     f.inputs do
       f.input :disc_version_id

--- a/app/admin/disc_versions.rb
+++ b/app/admin/disc_versions.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register DiscVersion do
-  permit_params :disc_id, :version, :price, :jacket, :remove_jacket ,disc_contents_attributes: [:id, :content_type, :event_id, :_destroy]
+  permit_params :disc_id, :version, :price, :jacket, :remove_jacket,
+                disc_contents_attributes: [:id, :content_type, :event_id, :_destroy]
   remove_filter :jacket_attachment, :jacket_blob
 
   form do |f|
@@ -12,7 +13,7 @@ ActiveAdmin.register DiscVersion do
     end
 
     f.inputs do
-      f.has_many :disc_contents ,allow_destroy: true do|t|
+      f.has_many :disc_contents, allow_destroy: true do |t|
         t.input :content_type
         t.input :event_id
       end

--- a/app/admin/disc_versions.rb
+++ b/app/admin/disc_versions.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register DiscVersion do
-  permit_params :disc_id, :version, :price, :jacket, :remove_jacket
+  permit_params :disc_id, :version, :price, :jacket, :remove_jacket ,disc_contents_attributes: [:id, :content_type, :event_id, :_destroy]
   remove_filter :jacket_attachment, :jacket_blob
 
   form do |f|
@@ -9,6 +9,13 @@ ActiveAdmin.register DiscVersion do
       f.input :price
       f.input :jacket, as: :file, hint: f.object.jacket.present? ? image_tag(f.object.jacket) : nil
       f.input :remove_jacket, as: :boolean, required: false, label: '画像を削除する' if f.object.jacket.present?
+    end
+
+    f.inputs do
+      f.has_many :disc_contents ,allow_destroy: true do|t|
+        t.input :content_type
+        t.input :event
+      end
     end
 
     f.actions

--- a/app/admin/disc_versions.rb
+++ b/app/admin/disc_versions.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register DiscVersion do
     f.inputs do
       f.has_many :disc_contents ,allow_destroy: true do|t|
         t.input :content_type
-        t.input :event
+        t.input :event_id
       end
     end
 

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -1,3 +1,23 @@
 ActiveAdmin.register Disc do
-  permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type
+  permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type, disc_versions_attributes: [:id, :version, :price, :_destroy]
+
+  form do |f|
+    f.inputs do
+      f.input :title
+      f.input :title_ruby
+      f.input :production_type
+      f.input :announcement_date
+      f.input :release_date
+    end
+
+    f.inputs do
+      f.has_many :disc_versions, allow_destroy: true do|t|
+        t.input :version
+        t.input :price
+      end
+    end
+
+    f.actions
+  end
+
 end

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register Disc do
-  permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type, disc_versions_attributes: [:id, :version, :price, :_destroy]
+  permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type,
+                disc_versions_attributes: [:id, :version, :price, :_destroy]
 
   form do |f|
     f.inputs do
@@ -11,7 +12,7 @@ ActiveAdmin.register Disc do
     end
 
     f.inputs do
-      f.has_many :disc_versions, allow_destroy: true do|t|
+      f.has_many :disc_versions, allow_destroy: true do |t|
         t.input :version
         t.input :price
       end
@@ -19,5 +20,4 @@ ActiveAdmin.register Disc do
 
     f.actions
   end
-
 end

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -6,8 +6,8 @@ ActiveAdmin.register Disc do
       f.input :title
       f.input :title_ruby
       f.input :production_type
-      f.input :announcement_date
       f.input :release_date
+      f.input :announcement_date
     end
 
     f.inputs do

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -1,5 +1,7 @@
 class Disc < ApplicationRecord
   has_many :disc_versions, dependent: :destroy
+  accepts_nested_attributes_for :disc_versions, allow_destroy: true
+
   has_many :informations, as: :reportable, dependent: :destroy
   has_many :link_contents, as: :linkable, dependent: :destroy
 

--- a/app/models/disc_content.rb
+++ b/app/models/disc_content.rb
@@ -2,6 +2,7 @@ class DiscContent < ApplicationRecord
   belongs_to :disc_version
   belongs_to :event, optional: true
   has_many :disc_items, dependent: :destroy
+  accepts_nested_attributes_for :disc_items, allow_destroy: true
 
   validates :content_type, presence: true
 

--- a/app/models/disc_version.rb
+++ b/app/models/disc_version.rb
@@ -1,6 +1,8 @@
 class DiscVersion < ApplicationRecord
   belongs_to :disc
   has_many :disc_contents, dependent: :destroy
+  accepts_nested_attributes_for :disc_contents, allow_destroy: true
+
   has_one_attached :jacket
 
   validates :version, presence: true


### PR DESCRIPTION
## 概要
Disc関連の情報を一括登録できるように変更

## 加えた変更
* Disc管理ページでDiscVersionsの情報を複数追加できるよう変更
  [![Image from Gyazo](https://i.gyazo.com/9fc7c17f6a89089b9fdde0995cb1e115.png)](https://gyazo.com/9fc7c17f6a89089b9fdde0995cb1e115)
* DiscVersion管理ページでDiscContentsの情報を複数追加できるよう変更
  [![Image from Gyazo](https://i.gyazo.com/7aa32b112e73739838ffeb5504d1c13d.png)](https://gyazo.com/7aa32b112e73739838ffeb5504d1c13d)
* DiscContent管理ページでDiscItemsの情報を複数追加できるよう変更
  [![Image from Gyazo](https://i.gyazo.com/6ac31736cbeb2700887c08b2cd76193f.png)](https://gyazo.com/6ac31736cbeb2700887c08b2cd76193f)

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #359 
