### PR TITLE
Fix Disc詳細画面の表示を修正

### DIFF
--- a/app/views/discs/_content.html.erb
+++ b/app/views/discs/_content.html.erb
@@ -1,11 +1,9 @@
-<% @disc_contents.each do |content| %>
-  <% if content.disc_version_id == version.id %>
-    <div class="my-3">
-      <%  if content.events? %>
-        <%= link_to "【" + content.event.name + " ＠" + content.event.place + "】", event_path(content.event_id), class: "link" %>
-      <% end %>
-      <%= "【特典映像】" if content.others? %>
-    </div>
-    <%= render partial: "item", locals: {content: content} %>
-  <% end %>
+<% contents.each do |content| %>
+  <div class="my-3">
+    <%  if content.events? %>
+      <%= link_to "【" + content.event.name + " ＠" + content.event.place + "】", event_path(content.event_id), class: "link" %>
+    <% end %>
+    <%= "【特典映像】" if content.others? %>
+  </div>
+  <%= render partial: "item", locals: { content: content, items: @disc_items.where(disc_content_id: content.id) } %>
 <% end %>

--- a/app/views/discs/_item.html.erb
+++ b/app/views/discs/_item.html.erb
@@ -1,8 +1,9 @@
-<% @disc_items.each do |item| %>
+<% items.each do |item| %>
   <div class="mb-2">
-    <% if item.disc_content_id == content.id && item.song_id.present? %>
+    <% if item.song_id.present? %>
       <%= link_to show_item_title(item), song_path(item.song_id) %>
+    <% else %>
+      <p><%= item.position.to_s + ". " + item.title if item.title.present? %></p>
     <% end %>
-    <p><%= item.position.to_s + ". " + item.title if item.disc_content_id == content.id && item.title.present? %></p>
   </div>
 <% end %>

--- a/app/views/discs/_version.html.erb
+++ b/app/views/discs/_version.html.erb
@@ -13,7 +13,7 @@
           <p class="text-center">画像読み込み中...</p>
         </div>
       </turbo-frame>
-      <%= render partial: "content", locals: {version: version} %>
+      <%= render partial: "content", locals: {version: version, contents: @disc_contents.where(disc_version_id: version.id)} %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要
ディスク詳細画面で下記のように表示がバグってしまう件を解消
[![Image from Gyazo](https://i.gyazo.com/0b07fab6b071e6a341811d0f375efb57.png)](https://gyazo.com/0b07fab6b071e6a341811d0f375efb57)

## 加えた変更
* バグの原因：`title`カラムと`song_id`カラム両方が指定されていた際に、二重で表示される仕様になっていた。
  →`song_id`カラムがある場合はリンク付きで、そうでない場合はリンクなしで表示するように変更

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #358 
