### PR TITLE
Feat イベント・ツアーの管理画面作成

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,3 +1,21 @@
 ActiveAdmin.register Event do
   remove_filter :tour, :event_informations, :event_bookmarks, :disc_contents, :setlist, :link_contents, :visual_image_attachment, :visual_image_blob, :place, :remark, :is_canceled
+  permit_params :category, :name, :name_kana_ruby, :date, :place, :place_prefecture, :remark, :is_canceled, :visual_image, :remove_visual_image
+
+  form do |f|
+    f.inputs do
+      f.input :category
+      f.input :name
+      f.input :name_kana_ruby
+      f.input :date
+      f.input :place
+      f.input :place_prefecture
+      f.input :remark
+      f.input :is_canceled
+      f.input :visual_image, as: :file, hint: f.object.visual_image.present? ? image_tag(f.object.visual_image) : nil
+      f.input :remove_visual_image, as: :boolean, required: false, label: '画像を削除する' if f.object.visual_image.present?
+    end
+
+    f.actions
+  end
 end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Event do
+  remove_filter :tour, :event_informations, :event_bookmarks, :disc_contents, :setlist, :link_contents, :visual_image_attachment, :visual_image_blob, :place, :remark, :is_canceled
+end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,6 +1,15 @@
 ActiveAdmin.register Event do
-  remove_filter :tour, :event_informations, :event_bookmarks, :disc_contents, :setlist, :link_contents, :visual_image_attachment, :visual_image_blob, :place, :remark, :is_canceled
-  permit_params :category, :name, :name_kana_ruby, :date, :place, :place_prefecture, :remark, :is_canceled, :visual_image, :remove_visual_image
+  remove_filter :tour, :event_informations, :event_bookmarks, :disc_contents, :setlist, :link_contents, :visual_image_attachment,
+                :visual_image_blob, :place, :remark, :is_canceled
+  permit_params :category, :name, :name_kana_ruby, :date, :place, :place_prefecture, :remark, :is_canceled, :visual_image,
+                :remove_visual_image
+
+  index do
+    column :category
+    column :name
+    column :date
+    actions
+  end
 
   form do |f|
     f.inputs do

--- a/app/admin/songs.rb
+++ b/app/admin/songs.rb
@@ -13,11 +13,6 @@ ActiveAdmin.register Song do
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
   # end
-  remove_filter :song_informations
-  remove_filter :disc_items
-  remove_filter :link_contents
-  remove_filter :jk_attachment
-  remove_filter :jk_blob
-  remove_filter :youtube_link
+  remove_filter :song_informations, :disc_items, :link_contents, :jk_attachment, :jk_blob, :youtube_link
   permit_params :name, :name_kana_ruby, :name_hiragana_ruby, :announcement_date, :youtube_link
 end

--- a/app/admin/tours.rb
+++ b/app/admin/tours.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Tour do
+  remove_filter :events
+end

--- a/app/admin/tours.rb
+++ b/app/admin/tours.rb
@@ -1,7 +1,9 @@
 ActiveAdmin.register Tour do
   remove_filter :events
 
-  permit_params :name, :name_kana_ruby, events_attributes: [:category, :name, :name_kana_ruby, :date, :place, :place_prefecture, :remark, :is_canceled, :_destroy]
+  permit_params :name, :name_kana_ruby,
+                events_attributes: [:category, :name, :name_kana_ruby, :date, :place, :place_prefecture,
+                                    :remark, :is_canceled, :_destroy]
 
   form do |f|
     f.inputs do

--- a/app/admin/tours.rb
+++ b/app/admin/tours.rb
@@ -2,4 +2,26 @@ ActiveAdmin.register Tour do
   remove_filter :events
 
   permit_params :name, :name_kana_ruby, events_attributes: [:category, :name, :name_kana_ruby, :date, :place, :place_prefecture, :remark, :is_canceled, :_destroy]
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :name_kana_ruby
+    end
+
+    f.inputs do
+      f.has_many :events, allow_destroy: true do |t|
+        t.input :name
+        t.input :name_kana_ruby
+        t.input :date
+        t.input :category
+        t.input :place_prefecture
+        t.input :place
+        t.input :is_canceled
+        t.input :remark
+      end
+    end
+
+    f.actions
+  end
 end

--- a/app/admin/tours.rb
+++ b/app/admin/tours.rb
@@ -1,3 +1,5 @@
 ActiveAdmin.register Tour do
   remove_filter :events
+
+  permit_params :name, :name_kana_ruby, events_attributes: [:category, :name, :name_kana_ruby, :date, :place, :place_prefecture, :remark, :is_canceled, :_destroy]
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,4 +45,13 @@ class Event < ApplicationRecord
   def self.ransackable_associations(_auth_object = nil)
     %w[name name_kana_ruby]
   end
+
+  def remove_visual_image
+    @remove_visual_image || false
+  end
+
+  def remove_visual_image=(value)
+    attribute_will_change!('remove_visual_image') if remove_visual_image != value
+    @remove_visual_image = value
+  end
 end

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -7,11 +7,11 @@ class Tour < ApplicationRecord
   validates :name, presence: true
   validates :name_kana_ruby, presence: true
 
-  def self.ransackable_associations(auth_object = nil)
-    ["events", "link_contents", "tour_informations"]
+  def self.ransackable_associations(_auth_object = nil)
+    %w[events link_contents tour_informations]
   end
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["created_at", "id", "id_value", "name", "name_kana_ruby", "updated_at"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at id id_value name name_kana_ruby updated_at]
   end
 end

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -5,4 +5,12 @@ class Tour < ApplicationRecord
 
   validates :name, presence: true
   validates :name_kana_ruby, presence: true
+
+  def self.ransackable_associations(auth_object = nil)
+    ["events", "link_contents", "tour_informations"]
+  end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "id", "id_value", "name", "name_kana_ruby", "updated_at"]
+  end
 end

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -1,5 +1,6 @@
 class Tour < ApplicationRecord
   has_many :events, dependent: :destroy
+  accepts_nested_attributes_for :events, allow_destroy: true
   has_many :tour_informations, dependent: :destroy
   has_many :link_contents, as: :linkable, dependent: :destroy
 

--- a/app/models/tour_information.rb
+++ b/app/models/tour_information.rb
@@ -10,7 +10,7 @@ class TourInformation < ApplicationRecord
     likes_on_tour_informations.exists?(user_id: user.id)
   end
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["body", "created_at", "id", "id_value", "tour_id", "updated_at", "user_id"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[body created_at id id_value tour_id updated_at user_id]
   end
 end

--- a/app/models/tour_information.rb
+++ b/app/models/tour_information.rb
@@ -9,4 +9,8 @@ class TourInformation < ApplicationRecord
   def liked_by?(user)
     likes_on_tour_informations.exists?(user_id: user.id)
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["body", "created_at", "id", "id_value", "tour_id", "updated_at", "user_id"]
+  end
 end

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -89,3 +89,4 @@ ja:
           Kagoshima: 鹿児島県
           Okinawa: 沖縄県
           abroad: 海外
+          other: place_prefecture


### PR DESCRIPTION
## 概要
イベントとツアーの管理画面を作成しました。
## 加えた変更
* イベント管理画面作成
  【管理画面 イベント一覧】
  [![Image from Gyazo](https://i.gyazo.com/d05aee60843f9c1821d8cedb82a61dd3.png)](https://gyazo.com/d05aee60843f9c1821d8cedb82a61dd3)
  【管理画面 イベント作成→保存】
  [![Image from Gyazo](https://i.gyazo.com/ceefe26baf160e4fa98bfaed82839557.gif)](https://gyazo.com/ceefe26baf160e4fa98bfaed82839557)
* ツアー管理画面作成
  【管理画面 ツアー一覧】
  [![Image from Gyazo](https://i.gyazo.com/b39f143693cb155f453888c84569a389.png)](https://gyazo.com/b39f143693cb155f453888c84569a389)
  【管理画面 ツアー作成画面】
  紐づくイベントも同時に作成できます。
  [![Image from Gyazo](https://i.gyazo.com/4e487cfb51da3c3427ac92e9f4043700.png)](https://gyazo.com/4e487cfb51da3c3427ac92e9f4043700)

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #233 
* close #234 
