### PR TITLE
Feat 各モデルのリンク管理フォームの作成

### DIFF
--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -1,6 +1,8 @@
 ActiveAdmin.register Disc do
+  remove_filter :links
   permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type,
-                disc_versions_attributes: [:id, :version, :price, :_destroy]
+                disc_versions_attributes: [:id, :version, :price, :_destroy],
+                link_contents_attributes: [:id, :link_id, :_destroy]
   menu parent: 'Disc'
 
   form do |f|
@@ -16,6 +18,12 @@ ActiveAdmin.register Disc do
       f.has_many :disc_versions, allow_destroy: true do |t|
         t.input :version
         t.input :price
+      end
+    end
+
+    f.inputs do
+      f.has_many :link_contents, allow_destroy: true do |t|
+        t.input :link_id, as: :select, collection: Link.all.order(remark: :asc).map { |x| [x.remark, x.id] }
       end
     end
 

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,8 +1,9 @@
 ActiveAdmin.register Event do
   remove_filter :tour, :event_informations, :event_bookmarks, :disc_contents, :setlist, :link_contents, :visual_image_attachment,
-                :visual_image_blob, :place, :remark, :is_canceled
+                :visual_image_blob, :place, :remark, :is_canceled, :links
   permit_params :category, :name, :name_kana_ruby, :date, :place, :place_prefecture, :remark, :is_canceled, :visual_image,
-                :remove_visual_image
+                :remove_visual_image,
+                link_contents_attributes: [:id, :link_id, :_destroy]
   menu parent: 'Event'
 
   index do
@@ -24,6 +25,12 @@ ActiveAdmin.register Event do
       f.input :is_canceled
       f.input :visual_image, as: :file, hint: f.object.visual_image.present? ? image_tag(f.object.visual_image) : nil
       f.input :remove_visual_image, as: :boolean, required: false, label: '画像を削除する' if f.object.visual_image.present?
+    end
+
+    f.inputs do
+      f.has_many :link_contents, allow_destroy: true do |t|
+        t.input :link_id, as: :select, collection: Link.all.order(remark: :asc).map { |x| [x.remark, x.id] }
+      end
     end
 
     f.actions

--- a/app/admin/songs.rb
+++ b/app/admin/songs.rb
@@ -1,18 +1,22 @@
 ActiveAdmin.register Song do
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :name, :name_kana_ruby, :youtube_link, :name_hiragana_ruby, :announcement_date
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:name, :name_kana_ruby, :youtube_link, :name_hiragana_ruby, :announcement_date]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
-  remove_filter :song_informations, :disc_items, :link_contents, :jk_attachment, :jk_blob, :youtube_link
-  permit_params :name, :name_kana_ruby, :name_hiragana_ruby, :announcement_date, :youtube_link
+  remove_filter :song_informations, :disc_items, :link_contents, :jk_attachment, :jk_blob, :youtube_link, :links
+  permit_params :name, :name_kana_ruby, :name_hiragana_ruby, :announcement_date,
+  link_contents_attributes: [:id, :link_id, :_destroy]
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :name_kana_ruby
+      f.input :name_hiragana_ruby
+      f.input :announcement_date
+    end
+
+    f.inputs do
+      f.has_many :link_contents, allow_destroy: true do |t|
+        t.input :link_id, as: :select, collection: Link.all.order(remark: :asc).map { |x| [x.remark, x.id] }
+      end
+    end
+
+    f.actions
+  end
 end

--- a/app/admin/tours.rb
+++ b/app/admin/tours.rb
@@ -1,8 +1,8 @@
 ActiveAdmin.register Tour do
   remove_filter :events, :links
 
-  permit_params :name, :name_kana_ruby,
-                events_attributes: [:category, :name, :name_kana_ruby, :date, :place, :place_prefecture,
+  permit_params :tour_id, :id, :name, :name_kana_ruby,
+                events_attributes: [:id, :category, :name, :name_kana_ruby, :date, :place, :place_prefecture,
                                     :remark, :is_canceled, :_destroy],
                 link_contents_attributes: [:id, :link_id, :_destroy]
   menu parent: 'Event'

--- a/app/admin/tours.rb
+++ b/app/admin/tours.rb
@@ -1,15 +1,22 @@
 ActiveAdmin.register Tour do
-  remove_filter :events
+  remove_filter :events, :links
 
   permit_params :name, :name_kana_ruby,
                 events_attributes: [:category, :name, :name_kana_ruby, :date, :place, :place_prefecture,
-                                    :remark, :is_canceled, :_destroy]
+                                    :remark, :is_canceled, :_destroy],
+                link_contents_attributes: [:id, :link_id, :_destroy]
   menu parent: 'Event'
 
   form do |f|
     f.inputs do
       f.input :name
       f.input :name_kana_ruby
+    end
+
+    f.inputs do
+      f.has_many :link_contents, allow_destroy: true do |t|
+        t.input :link_id, as: :select, collection: Link.all.order(remark: :asc).map { |x| [x.remark, x.id] }
+      end
     end
 
     f.inputs do

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -4,6 +4,8 @@ class Disc < ApplicationRecord
 
   has_many :informations, as: :reportable, dependent: :destroy
   has_many :link_contents, as: :linkable, dependent: :destroy
+  has_many :links, through: :link_contents
+  accepts_nested_attributes_for :link_contents, allow_destroy: true
 
   validates :title, presence: true
   validates :title_ruby, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,11 @@ class Event < ApplicationRecord
   has_many :event_bookmarks, dependent: :destroy
   has_many :disc_contents, dependent: :destroy
   has_one :setlist, dependent: :destroy
+
   has_many :link_contents, as: :linkable, dependent: :destroy
+  has_many :links, through: :link_contents
+  accepts_nested_attributes_for :link_contents, allow_destroy: true
+
   has_one_attached :visual_image
 
   validates :category, presence: true

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -2,6 +2,8 @@ class Song < ApplicationRecord
   has_many :song_informations, dependent: :destroy
   has_many :disc_items, dependent: :destroy
   has_many :link_contents, as: :linkable, dependent: :destroy
+  has_many :links, through: :link_contents
+  accepts_nested_attributes_for :link_contents, allow_destroy: true
   has_one_attached :jk
 
   with_options presence: true do

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -3,6 +3,8 @@ class Tour < ApplicationRecord
   accepts_nested_attributes_for :events, allow_destroy: true
   has_many :tour_informations, dependent: :destroy
   has_many :link_contents, as: :linkable, dependent: :destroy
+  accepts_nested_attributes_for :link_contents, allow_destroy: true
+  has_many :links, through: :link_contents
 
   validates :name, presence: true
   validates :name_kana_ruby, presence: true


### PR DESCRIPTION
## 概要
Song, Tourなどのモデル管理画面でリンクの紐付けをできるようにしました。

## 加えた変更
* Event管理画面でのリンク登録を行うためのフォーム追加
  [![Image from Gyazo](https://i.gyazo.com/ccc4c9f964ece3f6df280333a590989d.png)](https://gyazo.com/ccc4c9f964ece3f6df280333a590989d)
  上記のように複数のリンクを追加・削除することができます。
* Song, Tour, Discも同様のフォームを追加

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #364