### PR TITLE
Fix 動作速度の改善

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
     brakeman (7.0.0)
       racc
     builder (3.3.0)
+    bullet (8.0.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.40.0)
       addressable
@@ -504,6 +507,7 @@ GEM
     unicode-display_width (3.1.2)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uniform_notifier (1.16.0)
     uri (1.0.2)
     useragent (0.16.11)
     version_gem (1.1.4)
@@ -534,6 +538,7 @@ DEPENDENCIES
   activeadmin
   bootsnap
   brakeman
+  bullet
   capybara
   cssbundling-rails
   dartsass-rails (~> 0.5.1)

--- a/app/admin/disc_contents.rb
+++ b/app/admin/disc_contents.rb
@@ -3,6 +3,11 @@ ActiveAdmin.register DiscContent do
                 disc_items_attributes: [:id, :disc_content_id, :position, :song_id, :title, :is_arranged, :_destroy]
   menu parent: 'Disc'
 
+  includes :event, :disc_version
+
+  filter :created_at
+  filter :updated_at
+
   index do
     id_column
     column :disc_version
@@ -22,7 +27,7 @@ ActiveAdmin.register DiscContent do
       f.has_many :disc_items, allow_destroy: true do |t|
         t.input :position
         t.input :title
-        t.input :song
+        t.input :song_id, as: :select, collection: Song.select(:name, :id).all.order(name: :asc).map { |x| [x.name, x.id] }
         t.input :is_arranged
       end
     end

--- a/app/admin/disc_items.rb
+++ b/app/admin/disc_items.rb
@@ -2,6 +2,23 @@ ActiveAdmin.register DiscItem do
   permit_params :disc_content_id, :position, :song_id, :title, :is_arranged
   menu parent: 'Disc'
 
+  includes :disc_content, :song
+
+  filter :song
+  filter :title
+  filter :created_at
+  filter :updated_at
+
+  index do
+    id_column
+    column :id
+    column :disc_content
+    column :position
+    column :song
+    column :title
+    actions
+  end
+
   form do |f|
     f.inputs do
       f.input :disc_content_id

--- a/app/admin/disc_versions.rb
+++ b/app/admin/disc_versions.rb
@@ -1,8 +1,9 @@
 ActiveAdmin.register DiscVersion do
   permit_params :disc_id, :version, :price, :jacket, :remove_jacket,
                 disc_contents_attributes: [:id, :content_type, :event_id, :_destroy]
-  remove_filter :jacket_attachment, :jacket_blob
+  remove_filter :jacket_attachment, :jacket_blob, :disc_contents
   menu parent: 'Disc'
+  includes :disc
 
   form do |f|
     f.inputs do

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -5,6 +5,15 @@ ActiveAdmin.register Disc do
                 link_contents_attributes: [:id, :link_id, :_destroy]
   menu parent: 'Disc'
 
+  index do
+    column :id
+    column :title
+    column :announcement_date
+    column :release_date
+    column :production_type
+    actions
+  end
+
   form do |f|
     f.inputs do
       f.input :title

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register Event do
 
     f.inputs do
       f.has_many :link_contents, allow_destroy: true do |t|
-        t.input :link_id, as: :select, collection: Link.all.order(remark: :asc).map { |x| [x.remark, x.id] }
+        t.input :link_id, as: :select, collection: Link.select(:id, :remark).all.order(remark: :asc).map { |x| [x.remark, x.id] }
       end
     end
 

--- a/app/admin/histories.rb
+++ b/app/admin/histories.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register History do
-  remove_filter :image_attachment, :image_blob
+  includes :user
+  remove_filter :image_attachment, :image_blob, :user, :likes, :informations
   permit_params :title, :user_id, :date, :remark, :image, :remove_image
   form do |f|
     f.inputs do

--- a/app/admin/links.rb
+++ b/app/admin/links.rb
@@ -1,3 +1,7 @@
 ActiveAdmin.register Link do
+  includes :link_contents
   permit_params :platform, :url_link, :remark
+  filter :created_at
+  filter :updated_at
+  filter :remark
 end

--- a/app/admin/links.rb
+++ b/app/admin/links.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register Link do
-  includes :link_contents
   permit_params :platform, :url_link, :remark
   filter :created_at
   filter :updated_at

--- a/app/admin/tours.rb
+++ b/app/admin/tours.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register Tour do
-  remove_filter :events, :links
+  filter :created_at
+  filter :updated_at
 
   permit_params :tour_id, :id, :name, :name_kana_ruby,
                 events_attributes: [:id, :category, :name, :name_kana_ruby, :date, :place, :place_prefecture,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION
## 概要
ActiveAdmin導入に伴い、本番環境の動作が重くなってしまったため、改善を試みた。

## 加えた変更
* N+1問題検知のためのgem `bullet`の導入
* 各モデルの管理画面でのN+1問題の解消や、不要なモデルの読み込みの削除

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #

## 主に参考にした記事
* https://qiita.com/ogins57/items/6a17a96288ef702ac638