### PR TITLE
Fix 楽曲管理画面のフィルター削除

### DIFF
--- a/app/admin/songs.rb
+++ b/app/admin/songs.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Song do
-  remove_filter :song_informations, :disc_items, :link_contents, :jk_attachment, :jk_blob, :youtube_link, :links
+  remove_filter :song_informations, :disc_items, :link_contents, :jk_attachment, :jk_blob, :youtube_link, :links, :tie_ups
   permit_params :name, :name_kana_ruby, :name_hiragana_ruby, :announcement_date,
                 link_contents_attributes: [:id, :link_id, :_destroy]
 


### PR DESCRIPTION
## 概要
タイアップテーブル追加に伴う楽曲管理画面でのバグを修正しました。

## 加えた変更
* `remove_filter`に`tie_ups`を追加

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
