### PR TITLE
Add DiscDatesテーブル追加

### DIFF
--- a/app/admin/disc_dates.rb
+++ b/app/admin/disc_dates.rb
@@ -1,0 +1,4 @@
+ActiveAdmin.register DiscDate do
+  menu parent: 'Disc'
+  permit_params :date, :disc_id, :date_type, :remark
+end

--- a/app/admin/disc_dates.rb
+++ b/app/admin/disc_dates.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register DiscDate do
   menu parent: 'Disc'
   permit_params :date, :disc_id, :date_type, :remark
+  includes([:disc])
 end

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Disc do
-  remove_filter :links
+  remove_filter :links, :disc_dates
   permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type,
                 disc_versions_attributes: [:id, :version, :price, :_destroy],
                 link_contents_attributes: [:id, :link_id, :_destroy]

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -2,7 +2,8 @@ ActiveAdmin.register Disc do
   remove_filter :links, :disc_dates
   permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type,
                 disc_versions_attributes: [:id, :version, :price, :_destroy],
-                link_contents_attributes: [:id, :link_id, :_destroy]
+                link_contents_attributes: [:id, :link_id, :_destroy],
+                disc_dates_attributes: [:id, :date_type, :date, :remark, :_destroy]
   menu parent: 'Disc'
 
   index do
@@ -27,6 +28,14 @@ ActiveAdmin.register Disc do
       f.has_many :disc_versions, allow_destroy: true do |t|
         t.input :version
         t.input :price
+      end
+    end
+
+    f.inputs do
+      f.has_many :disc_dates, allow_destroy: true do |t|
+        t.input :date_type
+        t.input :date
+        t.input :remark
       end
     end
 

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -12,7 +12,6 @@ class Disc < ApplicationRecord
 
   validates :title, presence: true
   validates :title_ruby, presence: true
-  validates :release_date, presence: true
   validates :production_type, presence: true
 
   enum :production_type, { single: 0, ep: 1, album: 2, movie: 3 }

--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -2,6 +2,9 @@ class Disc < ApplicationRecord
   has_many :disc_versions, dependent: :destroy
   accepts_nested_attributes_for :disc_versions, allow_destroy: true
 
+  has_many :disc_dates, dependent: :destroy
+  accepts_nested_attributes_for :disc_dates, allow_destroy: true
+
   has_many :informations, as: :reportable, dependent: :destroy
   has_many :link_contents, as: :linkable, dependent: :destroy
   has_many :links, through: :link_contents

--- a/app/models/disc_date.rb
+++ b/app/models/disc_date.rb
@@ -6,4 +6,12 @@ class DiscDate < ApplicationRecord
   belongs_to :disc
 
   enum :date_type, { announcement: 0, release: 1, postponement: 2 }
+
+  def self.ransackable_associations(auth_object = nil)
+    ["disc"]
+  end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "date", "date_type", "disc_id", "id", "remark", "updated_at"]
+  end
 end

--- a/app/models/disc_date.rb
+++ b/app/models/disc_date.rb
@@ -1,17 +1,16 @@
 class DiscDate < ApplicationRecord
   validates :date, presence: true
-  validates :disc_id, presence: true
   validates :date_type, presence: true
 
   belongs_to :disc
 
   enum :date_type, { announcement: 0, release: 1, postponement: 2 }
 
-  def self.ransackable_associations(auth_object = nil)
-    ["disc"]
+  def self.ransackable_associations(_auth_object = nil)
+    ['disc']
   end
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["created_at", "date", "date_type", "disc_id", "id", "remark", "updated_at"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at date date_type disc_id id remark updated_at]
   end
 end

--- a/app/models/disc_date.rb
+++ b/app/models/disc_date.rb
@@ -3,5 +3,7 @@ class DiscDate < ApplicationRecord
   validates :disc_id, presence: true
   validates :date_type, presence: true
 
+  belongs_to :disc
+
   enum :date_type, { announcement: 0, release: 1, postponement: 2 }
 end

--- a/app/models/disc_date.rb
+++ b/app/models/disc_date.rb
@@ -1,0 +1,7 @@
+class DiscDate < ApplicationRecord
+  validates :date, presence: true
+  validates :disc_id, presence: true
+  validates :date_type, presence: true
+
+  enum :date_type, { announcement: 0, release: 1, postponement: 2 }
+end

--- a/db/migrate/20250110073709_create_disc_dates.rb
+++ b/db/migrate/20250110073709_create_disc_dates.rb
@@ -1,0 +1,12 @@
+class CreateDiscDates < ActiveRecord::Migration[8.0]
+  def change
+    create_table :disc_dates do |t|
+      t.date :date, null: false
+      t.integer :disc_id, null: false
+      t.integer :date_type, null: false
+      t.text :remark
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250110080942_change_release_date_column_to_null.rb
+++ b/db/migrate/20250110080942_change_release_date_column_to_null.rb
@@ -1,0 +1,5 @@
+class ChangeReleaseDateColumnToNull < ActiveRecord::Migration[8.0]
+  def up
+    change_column_null :discs, :release_date, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_10_052106) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_10_073709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -74,6 +74,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_10_052106) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "event_id"
+  end
+
+  create_table "disc_dates", force: :cascade do |t|
+    t.date "date", null: false
+    t.integer "disc_id", null: false
+    t.integer "date_type", null: false
+    t.text "remark"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "disc_items", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_10_073709) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_10_080942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -107,7 +107,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_10_073709) do
     t.string "title", null: false
     t.string "title_ruby", null: false
     t.date "announcement_date"
-    t.date "release_date", null: false
+    t.date "release_date"
     t.integer "production_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## 概要
DiscDatesテーブルを追加し、関連ページを整理しました。

## 加えた変更
* Discのアナウンス日・解禁日・延期発表日を追加する用のDiscDatesテーブルを追加
  * DiscDatesの管理画面作成
    【一覧画面】
    [![Image from Gyazo](https://i.gyazo.com/4614e95c475fc7e33d056d79ab6f66a5.png)](https://gyazo.com/4614e95c475fc7e33d056d79ab6f66a5)
* Discの管理画面にDiscDates登録フォームを追加
  [![Image from Gyazo](https://i.gyazo.com/3bc467aa6cf7e8642e734af756d00d0f.png)](https://gyazo.com/3bc467aa6cf7e8642e734af756d00d0f)

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* #343 
