### PR TITLE
Improve ヒストリー関連のパーシャル整理

### DIFF
--- a/app/admin/tie_ups.rb
+++ b/app/admin/tie_ups.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register TieUp do
   remove_filter :image_attachment, :image_blob, :is_new_song
-  permit_params :collaboration_title, :song_id, :announce_date, :remark, :is_new_song, :jacket, :remove_jacket
+  permit_params :collaboration_title, :song_id, :announcement_date, :remark, :is_new_song, :jacket, :remove_jacket
   includes([:song])
 end

--- a/app/models/tie_up.rb
+++ b/app/models/tie_up.rb
@@ -2,7 +2,7 @@ class TieUp < ApplicationRecord
   belongs_to :song
 
   validates :collaboration_title, presence: true
-  validates :announce_date, presence: true
+  validates :announcement_date, presence: true
   validates :is_new_song, inclusion: [true, false]
 
   has_one_attached :image

--- a/app/views/histories/_tie_up.html.erb
+++ b/app/views/histories/_tie_up.html.erb
@@ -12,7 +12,7 @@
       </div>
       <div class="divider divider-horizontal"></div>
       <div class="flex flex-col justify-center w-2/3 md:w-4/5 text-base md:text-lg lg:text-xl">
-        <p class=""><%= tie_up.collaboration_title %>と<%= "新曲" if tie_up.is_new_song? %><%= link_to tie_up.song.name, song_path(tie_up.song), class: "link mx-1" %>とのタイアップ発表</p>
+        <p class=""><%= tie_up.collaboration_title %>と<%= "新曲" if tie_up.is_new_song? %><%= link_to tie_up.song.name, song_path(tie_up.song), class: "link mx-1" %>のタイアップ発表</p>
       </div>
     </div>
   <hr />

--- a/app/views/histories/_timeline_mark.html.erb
+++ b/app/views/histories/_timeline_mark.html.erb
@@ -43,32 +43,4 @@
         <div class="w-5"></div>
       <% end %>
     </div>
-<% 
-=begin
-%>
-  <% when Disc %>
-    <% if previous_history.date_inspection(object_date) %>
-      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
-        <%= I18n.l(object_date, format: "%Y/%m/%d(%a)") %>
-      </div>
-    <% end %>
-    <div class="timeline-middle">
-      <% if previous_history.date_inspection(object_date) %>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="<%= "currentColor" if object_date <= Time.zone.today %>"
-          class="h-5 w-5">
-          <path
-            fill-rule="<%= "evenodd" if object_date <= Time.zone.today %>"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-            clip-rule="evenodd" />
-        </svg>
-      <% else %>
-        <div class="w-5"></div>
-      <% end %>
-    </div>
-<%
-=end
-%>
 <% end %>

--- a/app/views/histories/_timeline_mark.html.erb
+++ b/app/views/histories/_timeline_mark.html.erb
@@ -1,46 +1,21 @@
-<% case previous_history %>
-  <% when History, Event %>
-    <% if object_date != previous_history.date %>
-      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
-        <%= I18n.l(object_date, format: "%Y/%m/%d(%a)") %>
-      </div>
-    <% end %>
-    <div class="timeline-middle">
-      <% if object_date != previous_history.date %>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="<%= "currentColor" if object_date <= Time.zone.today %>"
-          class="h-5 w-5">
-          <path
-            fill-rule="<%= "evenodd" if object_date <= Time.zone.today %>"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-            clip-rule="evenodd" />
-        </svg>
-      <% else %>
-        <div class="w-5"></div>
-      <% end %>
-    </div>
-    <% when TieUp %>
-    <% if object_date != previous_history.announcement_date %>
-      <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
-        <%= I18n.l(object_date, format: "%Y/%m/%d(%a)") %>
-      </div>
-    <% end %>
-    <div class="timeline-middle">
-      <% if object_date != previous_history.announcement_date %>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="<%= "currentColor" if object_date <= Time.zone.today %>"
-          class="h-5 w-5">
-          <path
-            fill-rule="<%= "evenodd" if object_date <= Time.zone.today %>"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-            clip-rule="evenodd" />
-        </svg>
-      <% else %>
-        <div class="w-5"></div>
-      <% end %>
-    </div>
+<% if object_date != previous_history_date %>
+  <div class="timeline-start text-left text-sm md:text-lg lg:text-xl">
+    <%= I18n.l(object_date, format: "%Y/%m/%d(%a)") %>
+  </div>
 <% end %>
+<div class="timeline-middle">
+  <% if object_date != previous_history_date %>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="<%= "currentColor" if object_date <= Time.zone.today %>"
+      class="h-5 w-5">
+      <path
+        fill-rule="<%= "evenodd" if object_date <= Time.zone.today %>"
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+        clip-rule="evenodd" />
+    </svg>
+  <% else %>
+    <div class="w-5"></div>
+  <% end %>
+</div>

--- a/app/views/histories/_timeline_marks.html.erb
+++ b/app/views/histories/_timeline_marks.html.erb
@@ -1,3 +1,10 @@
+<% case previous_history %>
+  <% when History, Event %>
+    <% previous_history_date = previous_history.date %>
+  <% when TieUp %>
+    <% previous_history_date = previous_history.announcement_date %>
+<% end %>
+
 <% case history %>
   <% when History %>
     <%= render partial: "timeline_mark", locals: { object_date: history.date, previous_history_date: previous_history_date } %>

--- a/app/views/histories/_timeline_marks.html.erb
+++ b/app/views/histories/_timeline_marks.html.erb
@@ -1,10 +1,8 @@
 <% case history %>
   <% when History %>
-    <%= render partial: "timeline_mark", locals: { object_date: history.date, previous_history: previous_history } %>
-  <% when Disc %>
-    <%= render partial: "timeline_mark", locals: { object_date: history.release_date, previous_history: previous_history } %>
+    <%= render partial: "timeline_mark", locals: { object_date: history.date, previous_history_date: previous_history_date } %>
   <% when Event %>
-    <%= render partial: "timeline_mark", locals: { object_date: history.date, previous_history: previous_history } %>
+    <%= render partial: "timeline_mark", locals: { object_date: history.date, previous_history_date: previous_history_date } %>
   <% when TieUp %>
-    <%= render partial: "timeline_mark", locals: { object_date: history.announcement_date, previous_history: previous_history } %>
+    <%= render partial: "timeline_mark", locals: { object_date: history.announcement_date, previous_history_date: previous_history_date } %>
 <% end %>


### PR DESCRIPTION
## 概要
主にapp/views/histories/_timeline_mark.html.erbの整理を行いました。

## 加えた変更
* DRYの原則に則ったコードに修正しました。
  * 従来：app/views/histories/_timeline_mark.html.erb内で、`case`と`when`を用いて`previous_history`がEventかTieUpか…を判断（それぞれのクラスでビューの記述が必要）
  * 改善：app/views/histories/_timeline_marks.html.erbの方で判断を行い、全て`previous_history_date`に格納してapp/views/histories/_timeline_mark.html.erbへ受け渡し

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
