### PR TITLE
Feat メンバー一覧・詳細ページ

### DIFF
--- a/app/admin/members.rb
+++ b/app/admin/members.rb
@@ -1,8 +1,10 @@
 ActiveAdmin.register Member do
   remove_filter :image_attachment, :image_blob, :instruments
   permit_params :name, :name_ruby, :role, :x_link, :instagram, :thread, :birthday_year, :birthday_month, :birthday_day,
-                :blood_type, :mbti, :birth_place, :image, :remove_image, instruments_attributes: [:id, :name, :_destroy,
-                                                                           { gears_attributes: [:id, :name, :remark, :image,:remove_image, :_destroy] }]
+                :blood_type, :mbti, :birth_place, :image, :remove_image,
+                instruments_attributes: [:id, :name, :_destroy,
+                                         { gears_attributes:
+                                         [:id, :name, :remark, :image, :remove_image, :_destroy] }]
 
   index do
     selectable_column

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -10,4 +10,8 @@ class MembersController < ApplicationController
   def image
     @member = Member.find(params[:id])
   end
+
+  def gear_image
+    @gear = Gear.find(params[:id])
+  end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,4 +1,12 @@
 class MembersController < ApplicationController
   def index
+    @members = Member.all.order(:id)
+  end
+
+  def show
+  end
+
+  def image
+    @member = Member.find(params[:id])
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -4,6 +4,7 @@ class MembersController < ApplicationController
   end
 
   def show
+    @member = Member.eager_load(instruments: :gears).find(params[:id])
   end
 
   def image

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -5,6 +5,7 @@ class MembersController < ApplicationController
 
   def show
     @member = Member.eager_load([instruments: [gears: :image_attachment]], :image_attachment).find(params[:id])
+    sort_instruments(@member.instruments)
   end
 
   def image
@@ -13,5 +14,11 @@ class MembersController < ApplicationController
 
   def gear_image
     @gear = Gear.find(params[:id])
+  end
+
+  private
+
+  def sort_instruments(instruments)
+    # うまくいかなかったため後日実装
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,6 +1,6 @@
 class MembersController < ApplicationController
   def index
-    @members = Member.all.order(:id)
+    @members = Member.eager_load(:instruments).order(:id)
   end
 
   def show

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -4,7 +4,7 @@ class MembersController < ApplicationController
   end
 
   def show
-    @member = Member.eager_load(instruments: :gears).find(params[:id])
+    @member = Member.eager_load([instruments: [gears: :image_attachment]], :image_attachment).find(params[:id])
   end
 
   def image

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -3,7 +3,7 @@ class Instrument < ApplicationRecord
   has_many :gears, dependent: :destroy
   accepts_nested_attributes_for :gears, allow_destroy: true
 
-  enum :name, { guitar: 0, bass: 1, drums: 2, keyboard: 3, vocal: 4, other: 5, trumpet: 6}
+  enum :name, { vocal: 0, bass: 1, drums: 2, keyboard: 3, guitar: 4, sampler: 5, trumpet: 6, other: 20}
 
   validates :name, presence: true
 end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -3,7 +3,7 @@ class Instrument < ApplicationRecord
   has_many :gears, dependent: :destroy
   accepts_nested_attributes_for :gears, allow_destroy: true
 
-  enum :name, { guitar: 0, bass: 1, drums: 2, keyboard: 3, vocal: 4, other: 5 }
+  enum :name, { guitar: 0, bass: 1, drums: 2, keyboard: 3, vocal: 4, other: 5, trumpet: 6}
 
   validates :name, presence: true
 end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -3,7 +3,7 @@ class Instrument < ApplicationRecord
   has_many :gears, dependent: :destroy
   accepts_nested_attributes_for :gears, allow_destroy: true
 
-  enum :name, { vocal: 0, bass: 1, drums: 2, keyboard: 3, guitar: 4, sampler: 5, trumpet: 6, other: 20}
+  enum :name, { vocal: 0, bass: 1, drums: 2, keyboard: 3, guitar: 4, sampler: 5, trumpet: 6, other: 20 }
 
   validates :name, presence: true
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -14,11 +14,16 @@ class Member < ApplicationRecord
        { istj: 0, isfj: 1, infj: 2, intj: 3, istp: 4, isfp: 5, infp: 6, intp: 7, estp: 8, esfp: 9, enfp: 10, entp: 11, estj: 12,
          esfj: 13, enfj: 14, entj: 15 }
   enum :birth_place,
-       { Hokkaido: 0, Aomori: 1, Iwate: 2, Miyagi: 3, Akita: 4, Yamagata: 5, Fukushima: 6, Ibaraki: 7, Tochigi: 8, Gunma: 9,
-         Saitama: 10, Chiba: 11, Tokyo: 12, Kanagawa: 13, Niigata: 14, Toyama: 15, Ishikawa: 16, Fukui: 17, Yamanashi: 18, Nagano: 19,
-         Gifu: 20, Shizuoka: 21, Aichi: 22, Mie: 23, Shiga: 24, Kyoto: 25, Osaka: 26, Hyogo: 27, Nara: 28, Wakayama: 29, Tottori: 30,
-         Shimane: 31, Okayama: 32, Hiroshima: 33, Yamaguchi: 34, Tokushima: 35, Kagawa: 36, Ehime: 37, Kochi: 38, Fukuoka: 39, Saga: 40,
-         Nagasaki: 41, Kumamoto: 42, Oita: 43, Miyazaki: 44, Kagoshima: 45, Okinawa: 46, other: 47 }
+       { Hokkaido: 0, Aomori: 1, Iwate: 2, Miyagi: 3, Akita: 4, Yamagata: 5,
+         Fukushima: 6, Ibaraki: 7, Tochigi: 8, Gunma: 9,
+         Saitama: 10, Chiba: 11, Tokyo: 12, Kanagawa: 13, Niigata: 14,
+         Toyama: 15, Ishikawa: 16, Fukui: 17, Yamanashi: 18, Nagano: 19,
+         Gifu: 20, Shizuoka: 21, Aichi: 22, Mie: 23, Shiga: 24, Kyoto: 25,
+         Osaka: 26, Hyogo: 27, Nara: 28, Wakayama: 29, Tottori: 30,
+         Shimane: 31, Okayama: 32, Hiroshima: 33, Yamaguchi: 34, Tokushima: 35,
+         Kagawa: 36, Ehime: 37, Kochi: 38, Fukuoka: 39, Saga: 40,
+         Nagasaki: 41, Kumamoto: 42, Oita: 43, Miyazaki: 44, Kagoshima: 45,
+         Okinawa: 46, other: 47 }
 
   def self.ransackable_associations(_auth_object = nil)
     %w[image_attachment image_blob instruments]

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -1,0 +1,13 @@
+<div class="card w-full shadow-2xl mb-7 bg-base-300 text-base-content">
+  <figure>
+    <turbo-frame id="member_image_<%= member.id %>" src="/member/<%= member.id %>/image" loading="lazy">
+      <div class="my-3 flex">
+        <span class="loading loading-spinner loading-xs mr-1"></span>
+        <p class="text-center">画像読み込み中...</p>
+      </div>
+    </turbo-frame>
+  </figure>
+  <div class="card-body p-4">
+    <h2 class="card-title mb-3 link"><%= link_to member.name, member_path(member) %></h2>
+  </div>
+</div>

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -1,4 +1,4 @@
-<div class="card shadow-2xl mx-2 mb-7 bg-base-300 text-base-content">
+<div class="card shadow-2xl mx-2 mb-7 bg-base-300 max-w-80 text-base-content">
   <figure>
     <turbo-frame id="member_image_<%= member.id %>" src="/member/<%= member.id %>/image" loading="lazy">
       <div class="my-3 flex">

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -1,4 +1,4 @@
-<div class="card w-full shadow-2xl mb-7 bg-base-300 text-base-content">
+<div class="card shadow-2xl mx-2 mb-7 bg-base-300 text-base-content">
   <figure>
     <turbo-frame id="member_image_<%= member.id %>" src="/member/<%= member.id %>/image" loading="lazy">
       <div class="my-3 flex">

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -8,6 +8,14 @@
     </turbo-frame>
   </figure>
   <div class="card-body p-4">
-    <h2 class="card-title mb-3 link"><%= link_to member.name, member_path(member) %></h2>
+    <div class="flex items-end">
+      <h2 class="card-title link"><%= link_to member.name, member_path(member) %></h2>
+      <p class="ml-1 text-ms">(<%= member.role %>)</p>
+    </div>
+    <div>
+      <% member.instruments.each do |instrument| %>
+        <div class="badge badge-primary"><%= instrument.name %></div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/members/gear_image.html.erb
+++ b/app/views/members/gear_image.html.erb
@@ -1,0 +1,9 @@
+<turbo-frame id="gear_image_<%= @gear.id %>">
+  <% if @gear.image.attached? %>
+    <%= image_tag @gear.image.variant(resize_to_fill: [200, 200], format: :webp), class: "w-full" %>
+  <% else %>
+    <div class="skeleton w-full h-full flex items-center justify-center">
+      <p class="text-sm text-center">画像は<br>ちょい待ち</p>
+    </div>
+  <% end %>
+</turbo-frame>

--- a/app/views/members/image.html.erb
+++ b/app/views/members/image.html.erb
@@ -1,0 +1,7 @@
+<turbo-frame id="member_image_<%= @member.id %>">
+  <% if @member.image.attached? %>
+    <%= image_tag @member.image.variant(resize_to_fill: [400, 200], format: :webp) %>
+  <% else %>
+    <%= image_tag 'default_people_1.jpg', class: "h-40" %>
+  <% end %>
+</turbo-frame>

--- a/app/views/members/image.html.erb
+++ b/app/views/members/image.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="member_image_<%= @member.id %>">
   <% if @member.image.attached? %>
-    <%= image_tag @member.image.variant(resize_to_fill: [400, 200], format: :webp) %>
+    <%= image_tag @member.image.variant(resize_to_fit: [600, 600], format: :webp), class: "w-full" %>
   <% else %>
-    <%= image_tag 'default_people_1.jpg', class: "h-40" %>
+    <%= image_tag 'default_people_1.jpg', class: "w-full" %>
   <% end %>
 </turbo-frame>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,3 +1,15 @@
-<div class="m-10">
-  <p class="text-lg text-center">メンバーページは鋭意制作中です！</p>
+<div class="m-5">
+  <h1 class="flex justify-center text-3xl mb-5">
+    <%= title "メンバー一覧" %>
+  </h1>
+
+  <div class="flex justify-center">
+    <% if @members.present? %>
+      <div class="md:w-1/3 md:mx-3">
+        <%= render partial: 'members/member', collection: @members %>
+      </div>
+    <% else %>
+      <div class="mb-3">メンバー情報がありません</div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -5,7 +5,7 @@
 
   <div class="flex justify-center">
     <% if @members.present? %>
-      <div class="md:w-1/3 md:mx-3">
+      <div class="md:grid md:grid-cols-3">
         <%= render partial: 'members/member', collection: @members %>
       </div>
     <% else %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -9,63 +9,67 @@
     <h1 class="text-center text-xl md:text-2xl font-semibold mb-2">
       <%= @member.name %>
     </h1>
-    <% if @member.image.attached? %>
-      <div class="ml-5">
-        <%= image_tag @member.image.variant(resize_to_fit: [100, 100])%>
+    <div class="ml-5 h-32 w-32 md:h-48 md:w-48 lg:h-64 lg:w-64">
+      <turbo-frame id="member_image_<%= @member.id %>" src="/member/<%= @member.id %>/image" loading="lazy">
+        <div class="skeleton"></div>
+      </turbo-frame>
+    </div>
+  </div>
+
+  <div class="lg:grid lg:grid-cols-3 lg:gap-5">
+    <div class="lg:col-span-2">
+      <div class="divider mb-5">
+        <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">プロフィール</h2>
       </div>
-    <% end %>
-  </div>
-
-  <div>
-    <div class="divider mb-5">
-      <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">プロフィール</h2>
+      <div class="md:mx-5 md:text-lg lg:mx-10 lg:mb-10">
+        <p>
+          ・ メンバー名：<%= @member.name %>（<%= @member.name_ruby %>）
+        </p>
+        <p>
+          ・ 生年月日：
+          <% if @member.birthday_year.present? %>
+            <%= @member.birthday_year %>年
+          <% end %>
+          <% if @member.birthday_month.present? && @member.birthday_day.present? %>
+            <%= @member.birthday_month %>月<%= @member.birthday_day %>日<br>
+          <% else %>
+            生年月日不明（ご存じの方いたらご連絡ください。）
+          <% end %>
+        </p>
+        <p>
+          ・ 出身都道府県：<%= @member.birth_place.present? ? @member.birth_place : "不明（ご存じの方いたらご連絡ください。）" %>
+        </p>
+        <p>
+          ・ 血液型：<%= @member.blood_type.present? ? @member.blood_type.to_s + "型" : "不明（ご存じの方いたらご連絡ください。）" %>
+        </p>
+        <p>
+          ・ MBTI：<%= @member.mbti.present? ? @member.mbti : "不明（ご存じの方いたらご連絡ください。）" %>
+        </p>
+      </div>
     </div>
-    <div class="md:mx-5 md:text-lg lg:mx-10 lg:mb-10">
-      <p>
-        ・ メンバー名：<%= @member.name %>（<%= @member.name_ruby %>）
-      </p>
-      <p>
-        ・ 生年月日：
-        <% if @member.birthday_year.present? %>
-          <%= @member.birthday_year %>年
-        <% end %>
-        <% if @member.birthday_month.present? && @member.birthday_day.present? %>
-          <%= @member.birthday_month %>月<%= @member.birthday_day %>日<br>
-        <% else %>
-          生年月日不明（ご存じの方いたらご連絡ください。）
-        <% end %>
-      </p>
-      <p>
-        ・ 出身都道府県：<%= @member.birth_place.present? ? @member.birth_place : "不明（ご存じの方いたらご連絡ください。）" %>
-      </p>
-      <p>
-        ・ 血液型：<%= @member.blood_type.present? ? @member.blood_type.to_s + "型" : "不明（ご存じの方いたらご連絡ください。）" %>
-      </p>
-      <p>
-        ・ MBTI：<%= @member.mbti.present? ? @member.mbti : "不明（ご存じの方いたらご連絡ください。）" %>
-      </p>
-    </div>
-  </div>
 
-  <div class="divider mb-5 lg:mb-10">
-    <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">各種SNS</h2>
-  </div>
-  <div class="flex items-center justify-center mb-5 lg:mb-10">
-    <% if @member.x_link.present? %>
-      <%= link_to @member.x_link, target: "_blank" do %>
-        <i class="fa-brands fa-square-x-twitter fa-3x mx-3"></i>
-      <% end %>
-    <% end %>
-    <% if @member.instagram.present? %>
-      <%= link_to @member.instagram, target: "_blank" do %>
-        <i class="fa-brands fa-square-instagram fa-3x mx-3"></i>
-      <% end %>
-    <% end %>
-    <% if @member.thread.present? %>
-      <%= link_to @member.thread, target: "_blank" do %>
-        <i class="fa-brands fa-square-threads fa-3x mx-3", style="--fa-primary-opacity: 0.20"></i>
-      <% end %>
-    <% end %>
+    <div>
+      <div class="divider mb-5 lg:mb-10">
+        <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">各種SNS</h2>
+      </div>
+      <div class="flex items-center justify-center mb-5 lg:mb-10">
+        <% if @member.x_link.present? %>
+          <%= link_to @member.x_link, target: "_blank" do %>
+            <i class="fa-brands fa-square-x-twitter fa-3x mx-3"></i>
+          <% end %>
+        <% end %>
+        <% if @member.instagram.present? %>
+          <%= link_to @member.instagram, target: "_blank" do %>
+            <i class="fa-brands fa-square-instagram fa-3x mx-3"></i>
+          <% end %>
+        <% end %>
+        <% if @member.thread.present? %>
+          <%= link_to @member.thread, target: "_blank" do %>
+            <i class="fa-brands fa-square-threads fa-3x mx-3", style="--fa-primary-opacity: 0.20"></i>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <div class="divider mb-5">
@@ -73,23 +77,27 @@
   </div>
   <div class="md:mx-5 md:text-lg lg:mx-10 lg:mb-10">
     <ul class="list-disc list-inside">
-    <% @member.instruments.each do |instrument| %>
-      <li>
-        <%= instrument.name %>
-      </li>
-      <div class="ml-5">
-        <% instrument.gears.each do |gear| %>
-          <div class="">
-            ・<%= gear.name %>
-            <% if gear.image.attached? %>
-              <div class="ml-5 my-2">
-                <%= image_tag(gear.image.variant(resize_to_fill: [200, 200])) %>
+      <div class="md:grid md:grid-cols-2 md:gap-3 lg:grid-cols-3 lg:gap-5">
+      <% @member.instruments.each do |instrument| %>
+        <div>
+          <li>
+            <%= instrument.name %>
+          </li>
+          <div class="ml-5">
+            <% instrument.gears.each do |gear| %>
+              <div class="">
+                ・<%= gear.name %>
+                <% if gear.image.attached? %>
+                  <div class="ml-5 my-2">
+                    <%= image_tag(gear.image.variant(resize_to_fill: [200, 200])) %>
+                  </div>
+                <% end %>
               </div>
             <% end %>
           </div>
-        <% end %>
+        </div>
+      <% end %>
       </div>
-    <% end %>
     </ul>
   </div>
 </div>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,0 +1,33 @@
+<div class="m-5">
+  <h1 class="flex justify-center text-3xl mb-5">
+    <%= title "メンバー詳細" %>
+  </h1>
+
+  <div class="divider mb-3"></div>
+
+  <div class="mb-8 leading-8 flex justify-center items-center">
+    <h1 class="text-center text-xl md:text-2xl font-semibold mb-2">
+      <%= title @member.name %>
+    </h1>
+    <% if @member.image.attached? %>
+      <div class="ml-5">
+        <%= image_tag @member.image.variant(resize_to_fit: [100, 100])%>
+      </div>
+    <% end %>
+  </div>
+
+  <div>
+    <div class="divider mb-5">
+      <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">プロフィール</h2>
+    </div>
+    <p>
+      メンバー名：<%= @member.name %><br>
+      メンバー名（カナ）：<%= @member.name_ruby %><br>
+      生年月日：
+      <% if @member.birthday_year.present? %>
+        <%= @member.birthday_year %>年
+      <% end %>
+      <%= @member.birthday_month %>月<%= @member.birthday_day %>日<br>
+    </p>
+  </div>
+</div>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -21,13 +21,73 @@
       <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">プロフィール</h2>
     </div>
     <p>
-      メンバー名：<%= @member.name %><br>
-      メンバー名（カナ）：<%= @member.name_ruby %><br>
+      メンバー名：<%= @member.name %>（<%= @member.name_ruby %>）
+    </p>
+    <p>
       生年月日：
       <% if @member.birthday_year.present? %>
         <%= @member.birthday_year %>年
       <% end %>
-      <%= @member.birthday_month %>月<%= @member.birthday_day %>日<br>
+      <% if @member.birthday_month.present? && @member.birthday_day.present? %>
+        <%= @member.birthday_month %>月<%= @member.birthday_day %>日<br>
+      <% else %>
+        生年月日不明（ご存じの方いたらご連絡ください。）
+      <% end %>
     </p>
+    <p>
+      出身都道府県：<%= @member.birth_place.present? ? @member.birth_place : "不明（ご存じの方いたらご連絡ください。）" %>
+    </p>
+    <p>
+      血液型：<%= @member.blood_type.present? ? @member.blood_type.to_s + "型" : "不明（ご存じの方いたらご連絡ください。）" %>
+    </p>
+    <p>
+      MBTI：<%= @member.mbti.present? ? @member.mbti : "不明（ご存じの方いたらご連絡ください。）" %>
+    </p>
+  </div>
+
+  <div class="divider mb-5">
+    <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">各種SNS</h2>
+  </div>
+  <div class="flex items-center justify-center mb-5">
+    <% if @member.x_link.present? %>
+      <%= link_to @member.x_link, target: "_blank" do %>
+        <i class="fa-brands fa-square-x-twitter fa-3x mx-3"></i>
+      <% end %>
+    <% end %>
+    <% if @member.instagram.present? %>
+      <%= link_to @member.instagram, target: "_blank" do %>
+        <i class="fa-brands fa-square-instagram fa-3x mx-3"></i>
+      <% end %>
+    <% end %>
+    <% if @member.thread.present? %>
+      <%= link_to @member.thread, target: "_blank" do %>
+        <i class="fa-brands fa-square-threads fa-3x mx-3", style="--fa-primary-opacity: 0.20"></i>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="divider mb-5">
+    <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">担当楽器・使用機材</h2>
+  </div>
+  <div>
+    <ul class="list-disc list-inside">
+    <% @member.instruments.each do |instrument| %>
+      <li>
+        <%= instrument.name %>
+      </li>
+      <div class="ml-5">
+        <% instrument.gears.each do |gear| %>
+          <div class="">
+            ・<%= gear.name %>
+            <% if gear.image.attached? %>
+              <div class="ml-5 my-2">
+                <%= image_tag(gear.image.variant(resize_to_fill: [100, 100])) %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+    </ul>
   </div>
 </div>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -88,7 +88,7 @@
               <div class="">
                 ・<%= gear.name %>
                 <div class="my-3 h-32 w-32 md:h-48 md:w-48 lg:h-64 lg:w-64">
-                  <turbo-frame id="gear_image_<%= gear.id %>">
+                  <turbo-frame id="gear_image_<%= gear.id %>" src="/gear/<%= gear.id %>/image" loading="lazy">
                     <div class="skeleton w-full h-full"></div>
                   </turbo-frame>
                 </div>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -11,7 +11,7 @@
     </h1>
     <div class="ml-5 h-32 w-32 md:h-48 md:w-48 lg:h-64 lg:w-64">
       <turbo-frame id="member_image_<%= @member.id %>" src="/member/<%= @member.id %>/image" loading="lazy">
-        <div class="skeleton"></div>
+        <div class="skeleton h-full w-full"></div>
       </turbo-frame>
     </div>
   </div>
@@ -80,18 +80,18 @@
       <div class="md:grid md:grid-cols-2 md:gap-3 lg:grid-cols-3 lg:gap-5">
       <% @member.instruments.each do |instrument| %>
         <div>
-          <li>
+          <li class="text-lg md:text-xl lg:text-2xl md:mb-3">
             <%= instrument.name %>
           </li>
           <div class="ml-5">
             <% instrument.gears.each do |gear| %>
               <div class="">
                 ・<%= gear.name %>
-                <% if gear.image.attached? %>
-                  <div class="ml-5 my-2">
-                    <%= image_tag(gear.image.variant(resize_to_fill: [200, 200])) %>
-                  </div>
-                <% end %>
+                <div class="my-3 h-32 w-32 md:h-48 md:w-48 lg:h-64 lg:w-64">
+                  <turbo-frame id="gear_image_<%= gear.id %>">
+                    <div class="skeleton w-full h-full"></div>
+                  </turbo-frame>
+                </div>
                 <% if gear.remark.present? %>
                   <p class="ml-5">
                   （<%= gear.remark %>）

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -52,7 +52,7 @@
       <div class="divider mb-5 lg:mb-10">
         <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">各種SNS</h2>
       </div>
-      <div class="flex items-center justify-center mb-5 lg:mb-10">
+      <div class="flex items-center justify-center mb-5 md:mb-10">
         <% if @member.x_link.present? %>
           <%= link_to @member.x_link, target: "_blank" do %>
             <i class="fa-brands fa-square-x-twitter fa-3x mx-3"></i>
@@ -91,6 +91,11 @@
                   <div class="ml-5 my-2">
                     <%= image_tag(gear.image.variant(resize_to_fill: [200, 200])) %>
                   </div>
+                <% end %>
+                <% if gear.remark.present? %>
+                  <p class="ml-5">
+                  （<%= gear.remark %>）
+                  </p>
                 <% end %>
               </div>
             <% end %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -7,7 +7,7 @@
 
   <div class="mb-8 leading-8 flex justify-center items-center">
     <h1 class="text-center text-xl md:text-2xl font-semibold mb-2">
-      <%= title @member.name %>
+      <%= @member.name %>
     </h1>
     <% if @member.image.attached? %>
       <div class="ml-5">
@@ -20,35 +20,37 @@
     <div class="divider mb-5">
       <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">プロフィール</h2>
     </div>
-    <p>
-      メンバー名：<%= @member.name %>（<%= @member.name_ruby %>）
-    </p>
-    <p>
-      生年月日：
-      <% if @member.birthday_year.present? %>
-        <%= @member.birthday_year %>年
-      <% end %>
-      <% if @member.birthday_month.present? && @member.birthday_day.present? %>
-        <%= @member.birthday_month %>月<%= @member.birthday_day %>日<br>
-      <% else %>
-        生年月日不明（ご存じの方いたらご連絡ください。）
-      <% end %>
-    </p>
-    <p>
-      出身都道府県：<%= @member.birth_place.present? ? @member.birth_place : "不明（ご存じの方いたらご連絡ください。）" %>
-    </p>
-    <p>
-      血液型：<%= @member.blood_type.present? ? @member.blood_type.to_s + "型" : "不明（ご存じの方いたらご連絡ください。）" %>
-    </p>
-    <p>
-      MBTI：<%= @member.mbti.present? ? @member.mbti : "不明（ご存じの方いたらご連絡ください。）" %>
-    </p>
+    <div class="md:mx-5 md:text-lg lg:mx-10 lg:mb-10">
+      <p>
+        ・ メンバー名：<%= @member.name %>（<%= @member.name_ruby %>）
+      </p>
+      <p>
+        ・ 生年月日：
+        <% if @member.birthday_year.present? %>
+          <%= @member.birthday_year %>年
+        <% end %>
+        <% if @member.birthday_month.present? && @member.birthday_day.present? %>
+          <%= @member.birthday_month %>月<%= @member.birthday_day %>日<br>
+        <% else %>
+          生年月日不明（ご存じの方いたらご連絡ください。）
+        <% end %>
+      </p>
+      <p>
+        ・ 出身都道府県：<%= @member.birth_place.present? ? @member.birth_place : "不明（ご存じの方いたらご連絡ください。）" %>
+      </p>
+      <p>
+        ・ 血液型：<%= @member.blood_type.present? ? @member.blood_type.to_s + "型" : "不明（ご存じの方いたらご連絡ください。）" %>
+      </p>
+      <p>
+        ・ MBTI：<%= @member.mbti.present? ? @member.mbti : "不明（ご存じの方いたらご連絡ください。）" %>
+      </p>
+    </div>
   </div>
 
-  <div class="divider mb-5">
+  <div class="divider mb-5 lg:mb-10">
     <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">各種SNS</h2>
   </div>
-  <div class="flex items-center justify-center mb-5">
+  <div class="flex items-center justify-center mb-5 lg:mb-10">
     <% if @member.x_link.present? %>
       <%= link_to @member.x_link, target: "_blank" do %>
         <i class="fa-brands fa-square-x-twitter fa-3x mx-3"></i>
@@ -69,7 +71,7 @@
   <div class="divider mb-5">
     <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">担当楽器・使用機材</h2>
   </div>
-  <div>
+  <div class="md:mx-5 md:text-lg lg:mx-10 lg:mb-10">
     <ul class="list-disc list-inside">
     <% @member.instruments.each do |instrument| %>
       <li>
@@ -81,7 +83,7 @@
             ・<%= gear.name %>
             <% if gear.image.attached? %>
               <div class="ml-5 my-2">
-                <%= image_tag(gear.image.variant(resize_to_fill: [100, 100])) %>
+                <%= image_tag(gear.image.variant(resize_to_fill: [200, 200])) %>
               </div>
             <% end %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get '/history_link_views/:id' => "histories#link_view_image"
   get '/histories/images/:id' => "histories#show_page_image"
   get 'member/:id/image' => "members#image"
+  get 'gear/:id/image' => "members#gear_image"
 
   # （ここから）Twitter認証以外を認めないようにルーティングを設定しようとした痕跡
   # devise_for :users, skip: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get '/history_link_dates/:id' => "histories#link_date_image"
   get '/history_link_views/:id' => "histories#link_view_image"
   get '/histories/images/:id' => "histories#show_page_image"
+  get 'member/:id/image' => "members#image"
 
   # （ここから）Twitter認証以外を認めないようにルーティングを設定しようとした痕跡
   # devise_for :users, skip: :all
@@ -39,7 +40,7 @@ Rails.application.routes.draw do
   resources :notices, only: [:index]
   delete "notices" => "notices#destroy"
 
-  resources :members, only: [:index]
+  resources :members, only: [:index, :show]
   resources :histories, only: [:index, :new, :create, :show, :destroy, :edit, :update] do
     post "image/destroy" => "images#history_image_destroy"
     resources :informations, only: [:create], module: :histories


### PR DESCRIPTION
## 概要
メンバーの一覧ページと詳細ページを作成しました。

## 加えた変更
* メンバー一覧ページの作成
  （スマホ画面）
  ![Uploading スクリーンショット 2025-01-19 12.18.07.png…]()
  （PC画面）
  <img width="1198" alt="スクリーンショット 2025-01-19 12 17 54" src="https://github.com/user-attachments/assets/a81ee07a-ae78-4165-a1b4-e970c885615b" />
* メンバー詳細ページの作成
  （スマホ画面）
  <img width="337" alt="スクリーンショット 2025-01-19 12 18 53" src="https://github.com/user-attachments/assets/77de6de2-e00a-4d24-9fc2-36d4e66fda40" />
  （PC画面）
  <img width="1440" alt="スクリーンショット 2025-01-19 12 19 16" src="https://github.com/user-attachments/assets/afae7dae-ca29-4993-86b7-bf1246b4f072" />

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #23 
* #24
