### PR TITLE
Feat メンバーインフォ 投稿・表示

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link actiontext.css

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -1,0 +1,440 @@
+/*
+ * Default Trix editor styles. See Action Text overwrites below.
+*/
+
+trix-editor {
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  margin: 0;
+  padding: 0.4em 0.6em;
+  min-height: 5em;
+  outline: none; }
+
+trix-toolbar * {
+  box-sizing: border-box; }
+
+trix-toolbar .trix-button-row {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  overflow-x: auto; }
+
+trix-toolbar .trix-button-group {
+  display: flex;
+  margin-bottom: 10px;
+  border: 1px solid #bbb;
+  border-top-color: #ccc;
+  border-bottom-color: #888;
+  border-radius: 3px; }
+  trix-toolbar .trix-button-group:not(:first-child) {
+    margin-left: 1.5vw; }
+    @media (max-width: 768px) {
+      trix-toolbar .trix-button-group:not(:first-child) {
+        margin-left: 0; } }
+
+trix-toolbar .trix-button-group-spacer {
+  flex-grow: 1; }
+  @media (max-width: 768px) {
+    trix-toolbar .trix-button-group-spacer {
+      display: none; } }
+
+trix-toolbar .trix-button {
+  position: relative;
+  float: left;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.75em;
+  font-weight: 600;
+  white-space: nowrap;
+  padding: 0 0.5em;
+  margin: 0;
+  outline: none;
+  border: none;
+  border-bottom: 1px solid #ddd;
+  border-radius: 0;
+  background: transparent; }
+  trix-toolbar .trix-button:not(:first-child) {
+    border-left: 1px solid #ccc; }
+  trix-toolbar .trix-button.trix-active {
+    background: #cbeefa;
+    color: black; }
+  trix-toolbar .trix-button:not(:disabled) {
+    cursor: pointer; }
+  trix-toolbar .trix-button:disabled {
+    color: rgba(0, 0, 0, 0.125); }
+  @media (max-width: 768px) {
+    trix-toolbar .trix-button {
+      letter-spacing: -0.01em;
+      padding: 0 0.3em; } }
+
+trix-toolbar .trix-button--icon {
+  font-size: inherit;
+  width: 2.6em;
+  height: 1.6em;
+  max-width: calc(0.8em + 4vw);
+  text-indent: -9999px; }
+  @media (max-width: 768px) {
+    trix-toolbar .trix-button--icon {
+      height: 2em;
+      max-width: calc(0.8em + 3.5vw); } }
+  trix-toolbar .trix-button--icon::before {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    opacity: 0.6;
+    content: "";
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain; }
+    @media (max-width: 768px) {
+      trix-toolbar .trix-button--icon::before {
+        right: 6%;
+        left: 6%; } }
+  trix-toolbar .trix-button--icon.trix-active::before {
+    opacity: 1; }
+  trix-toolbar .trix-button--icon:disabled::before {
+    opacity: 0.125; }
+
+trix-toolbar .trix-button--icon-attach::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M10.5%2018V7.5c0-2.25%203-2.25%203%200V18c0%204.125-6%204.125-6%200V7.5c0-6.375%209-6.375%209%200V18%22%20stroke%3D%22%23000%22%20stroke-width%3D%222%22%20stroke-miterlimit%3D%2210%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E");
+  top: 8%;
+  bottom: 4%; }
+
+trix-toolbar .trix-button--icon-bold::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M6.522%2019.242a.5.5%200%200%201-.5-.5V5.35a.5.5%200%200%201%20.5-.5h5.783c1.347%200%202.46.345%203.24.982.783.64%201.216%201.562%201.216%202.683%200%201.13-.587%202.129-1.476%202.71a.35.35%200%200%200%20.049.613c1.259.56%202.101%201.742%202.101%203.22%200%201.282-.483%202.334-1.363%203.063-.876.726-2.132%201.12-3.66%201.12h-5.89ZM9.27%207.347v3.362h1.97c.766%200%201.347-.17%201.733-.464.38-.291.587-.716.587-1.27%200-.53-.183-.928-.513-1.198-.334-.273-.838-.43-1.505-.43H9.27Zm0%205.606v3.791h2.389c.832%200%201.448-.177%201.853-.497.399-.315.614-.786.614-1.423%200-.62-.22-1.077-.63-1.385-.418-.313-1.053-.486-1.905-.486H9.27Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-italic::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M9%205h6.5v2h-2.23l-2.31%2010H13v2H6v-2h2.461l2.306-10H9V5Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-link::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M18.948%205.258a4.337%204.337%200%200%200-6.108%200L11.217%206.87a.993.993%200%200%200%200%201.41c.392.39%201.027.39%201.418%200l1.623-1.613a2.323%202.323%200%200%201%203.271%200%202.29%202.29%200%200%201%200%203.251l-2.393%202.38a3.021%203.021%200%200%201-4.255%200l-.05-.049a1.007%201.007%200%200%200-1.418%200%20.993.993%200%200%200%200%201.41l.05.049a5.036%205.036%200%200%200%207.091%200l2.394-2.38a4.275%204.275%200%200%200%200-6.072Zm-13.683%2013.6a4.337%204.337%200%200%200%206.108%200l1.262-1.255a.993.993%200%200%200%200-1.41%201.007%201.007%200%200%200-1.418%200L9.954%2017.45a2.323%202.323%200%200%201-3.27%200%202.29%202.29%200%200%201%200-3.251l2.344-2.331a2.579%202.579%200%200%201%203.631%200c.392.39%201.027.39%201.419%200a.993.993%200%200%200%200-1.41%204.593%204.593%200%200%200-6.468%200l-2.345%202.33a4.275%204.275%200%200%200%200%206.072Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-strike::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M6%2014.986c.088%202.647%202.246%204.258%205.635%204.258%203.496%200%205.713-1.728%205.713-4.463%200-.275-.02-.536-.062-.781h-3.461c.398.293.573.654.573%201.123%200%201.035-1.074%201.787-2.646%201.787-1.563%200-2.773-.762-2.91-1.924H6ZM6.432%2010h3.763c-.632-.314-.914-.715-.914-1.273%200-1.045.977-1.739%202.432-1.739%201.475%200%202.52.723%202.617%201.914h2.764c-.05-2.548-2.11-4.238-5.39-4.238-3.145%200-5.392%201.719-5.392%204.316%200%20.363.04.703.12%201.02ZM4%2011a1%201%200%201%200%200%202h15a1%201%200%201%200%200-2H4Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-quote::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M4.581%208.471c.44-.5%201.056-.834%201.758-.995C8.074%207.17%209.201%207.822%2010%208.752c1.354%201.578%201.33%203.555.394%205.277-.941%201.731-2.788%203.163-4.988%203.56a.622.622%200%200%201-.653-.317c-.113-.205-.121-.49.16-.764.294-.286.567-.566.791-.835.222-.266.413-.54.524-.815.113-.28.156-.597.026-.908-.128-.303-.39-.524-.72-.69a3.02%203.02%200%200%201-1.674-2.7c0-.905.283-1.59.72-2.088Zm9.419%200c.44-.5%201.055-.834%201.758-.995%201.734-.306%202.862.346%203.66%201.276%201.355%201.578%201.33%203.555.395%205.277-.941%201.731-2.789%203.163-4.988%203.56a.622.622%200%200%201-.653-.317c-.113-.205-.122-.49.16-.764.294-.286.567-.566.791-.835.222-.266.412-.54.523-.815.114-.28.157-.597.026-.908-.127-.303-.39-.524-.72-.69a3.02%203.02%200%200%201-1.672-2.701c0-.905.283-1.59.72-2.088Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-heading-1::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M21.5%207.5v-3h-12v3H14v13h3v-13h4.5ZM9%2013.5h3.5v-3h-10v3H6v7h3v-7Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-code::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M3.293%2011.293a1%201%200%200%200%200%201.414l4%204a1%201%200%201%200%201.414-1.414L5.414%2012l3.293-3.293a1%201%200%200%200-1.414-1.414l-4%204Zm13.414%205.414%204-4a1%201%200%200%200%200-1.414l-4-4a1%201%200%201%200-1.414%201.414L18.586%2012l-3.293%203.293a1%201%200%200%200%201.414%201.414Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-bullet-list::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M5%207.5a1.5%201.5%200%201%200%200-3%201.5%201.5%200%200%200%200%203ZM8%206a1%201%200%200%201%201-1h11a1%201%200%201%201%200%202H9a1%201%200%200%201-1-1Zm1%205a1%201%200%201%200%200%202h11a1%201%200%201%200%200-2H9Zm0%206a1%201%200%201%200%200%202h11a1%201%200%201%200%200-2H9Zm-2.5-5a1.5%201.5%200%201%201-3%200%201.5%201.5%200%200%201%203%200ZM5%2019.5a1.5%201.5%200%201%200%200-3%201.5%201.5%200%200%200%200%203Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-number-list::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M3%204h2v4H4V5H3V4Zm5%202a1%201%200%200%201%201-1h11a1%201%200%201%201%200%202H9a1%201%200%200%201-1-1Zm1%205a1%201%200%201%200%200%202h11a1%201%200%201%200%200-2H9Zm0%206a1%201%200%201%200%200%202h11a1%201%200%201%200%200-2H9Zm-3.5-7H6v1l-1.5%202H6v1H3v-1l1.667-2H3v-1h2.5ZM3%2017v-1h3v4H3v-1h2v-.5H4v-1h1V17H3Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-undo::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M3%2014a1%201%200%200%200%201%201h6a1%201%200%201%200%200-2H6.257c2.247-2.764%205.151-3.668%207.579-3.264%202.589.432%204.739%202.356%205.174%205.405a1%201%200%200%200%201.98-.283c-.564-3.95-3.415-6.526-6.825-7.095C11.084%207.25%207.63%208.377%205%2011.39V8a1%201%200%200%200-2%200v6Zm2-1Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-redo::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M21%2014a1%201%200%200%201-1%201h-6a1%201%200%201%201%200-2h3.743c-2.247-2.764-5.151-3.668-7.579-3.264-2.589.432-4.739%202.356-5.174%205.405a1%201%200%200%201-1.98-.283c.564-3.95%203.415-6.526%206.826-7.095%203.08-.513%206.534.614%209.164%203.626V8a1%201%200%201%201%202%200v6Zm-2-1Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-decrease-nesting-level::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M5%206a1%201%200%200%201%201-1h12a1%201%200%201%201%200%202H6a1%201%200%200%201-1-1Zm4%205a1%201%200%201%200%200%202h9a1%201%200%201%200%200-2H9Zm-3%206a1%201%200%201%200%200%202h12a1%201%200%201%200%200-2H6Zm-3.707-5.707a1%201%200%200%200%200%201.414l2%202a1%201%200%201%200%201.414-1.414L4.414%2012l1.293-1.293a1%201%200%200%200-1.414-1.414l-2%202Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-button--icon-increase-nesting-level::before {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M5%206a1%201%200%200%201%201-1h12a1%201%200%201%201%200%202H6a1%201%200%200%201-1-1Zm4%205a1%201%200%201%200%200%202h9a1%201%200%201%200%200-2H9Zm-3%206a1%201%200%201%200%200%202h12a1%201%200%201%200%200-2H6Zm-2.293-2.293%202-2a1%201%200%200%200%200-1.414l-2-2a1%201%200%201%200-1.414%201.414L3.586%2012l-1.293%201.293a1%201%200%201%200%201.414%201.414Z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E"); }
+
+trix-toolbar .trix-dialogs {
+  position: relative; }
+
+trix-toolbar .trix-dialog {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  font-size: 0.75em;
+  padding: 15px 10px;
+  background: #fff;
+  box-shadow: 0 0.3em 1em #ccc;
+  border-top: 2px solid #888;
+  border-radius: 5px;
+  z-index: 5; }
+
+trix-toolbar .trix-input--dialog {
+  font-size: inherit;
+  font-weight: normal;
+  padding: 0.5em 0.8em;
+  margin: 0 10px 0 0;
+  border-radius: 3px;
+  border: 1px solid #bbb;
+  background-color: #fff;
+  box-shadow: none;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none; }
+  trix-toolbar .trix-input--dialog.validate:invalid {
+    box-shadow: #F00 0px 0px 1.5px 1px; }
+
+trix-toolbar .trix-button--dialog {
+  font-size: inherit;
+  padding: 0.5em;
+  border-bottom: none; }
+
+trix-toolbar .trix-dialog--link {
+  max-width: 600px; }
+
+trix-toolbar .trix-dialog__link-fields {
+  display: flex;
+  align-items: baseline; }
+  trix-toolbar .trix-dialog__link-fields .trix-input {
+    flex: 1; }
+  trix-toolbar .trix-dialog__link-fields .trix-button-group {
+    flex: 0 0 content;
+    margin: 0; }
+
+trix-editor [data-trix-mutable]:not(.attachment__caption-editor) {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none; }
+
+trix-editor [data-trix-mutable]::-moz-selection,
+trix-editor [data-trix-cursor-target]::-moz-selection, trix-editor [data-trix-mutable] ::-moz-selection {
+  background: none; }
+
+trix-editor [data-trix-mutable]::selection,
+trix-editor [data-trix-cursor-target]::selection, trix-editor [data-trix-mutable] ::selection {
+  background: none; }
+
+trix-editor .attachment__caption-editor:focus[data-trix-mutable]::-moz-selection {
+  background: highlight; }
+
+trix-editor .attachment__caption-editor:focus[data-trix-mutable]::selection {
+  background: highlight; }
+
+trix-editor [data-trix-mutable].attachment.attachment--file {
+  box-shadow: 0 0 0 2px highlight;
+  border-color: transparent; }
+
+trix-editor [data-trix-mutable].attachment img {
+  box-shadow: 0 0 0 2px highlight; }
+
+trix-editor .attachment {
+  position: relative; }
+  trix-editor .attachment:hover {
+    cursor: default; }
+
+trix-editor .attachment--preview .attachment__caption:hover {
+  cursor: text; }
+
+trix-editor .attachment__progress {
+  position: absolute;
+  z-index: 1;
+  height: 20px;
+  top: calc(50% - 10px);
+  left: 5%;
+  width: 90%;
+  opacity: 0.9;
+  transition: opacity 200ms ease-in; }
+  trix-editor .attachment__progress[value="100"] {
+    opacity: 0; }
+
+trix-editor .attachment__caption-editor {
+  display: inline-block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  color: inherit;
+  text-align: center;
+  vertical-align: top;
+  border: none;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none; }
+
+trix-editor .attachment__toolbar {
+  position: absolute;
+  z-index: 1;
+  top: -0.9em;
+  left: 0;
+  width: 100%;
+  text-align: center; }
+
+trix-editor .trix-button-group {
+  display: inline-flex; }
+
+trix-editor .trix-button {
+  position: relative;
+  float: left;
+  color: #666;
+  white-space: nowrap;
+  font-size: 80%;
+  padding: 0 0.8em;
+  margin: 0;
+  outline: none;
+  border: none;
+  border-radius: 0;
+  background: transparent; }
+  trix-editor .trix-button:not(:first-child) {
+    border-left: 1px solid #ccc; }
+  trix-editor .trix-button.trix-active {
+    background: #cbeefa; }
+  trix-editor .trix-button:not(:disabled) {
+    cursor: pointer; }
+
+trix-editor .trix-button--remove {
+  text-indent: -9999px;
+  display: inline-block;
+  padding: 0;
+  outline: none;
+  width: 1.8em;
+  height: 1.8em;
+  line-height: 1.8em;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 2px solid highlight;
+  box-shadow: 1px 1px 6px rgba(0, 0, 0, 0.25); }
+  trix-editor .trix-button--remove::before {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    opacity: 0.7;
+    content: "";
+    background-image: url("data:image/svg+xml,%3Csvg%20height%3D%2224%22%20width%3D%2224%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M19%206.41%2017.59%205%2012%2010.59%206.41%205%205%206.41%2010.59%2012%205%2017.59%206.41%2019%2012%2013.41%2017.59%2019%2019%2017.59%2013.41%2012z%22%2F%3E%3Cpath%20d%3D%22M0%200h24v24H0z%22%20fill%3D%22none%22%2F%3E%3C%2Fsvg%3E");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 90%; }
+  trix-editor .trix-button--remove:hover {
+    border-color: #333; }
+    trix-editor .trix-button--remove:hover::before {
+      opacity: 1; }
+
+trix-editor .attachment__metadata-container {
+  position: relative; }
+
+trix-editor .attachment__metadata {
+  position: absolute;
+  left: 50%;
+  top: 2em;
+  transform: translate(-50%, 0);
+  max-width: 90%;
+  padding: 0.1em 0.6em;
+  font-size: 0.8em;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 3px; }
+  trix-editor .attachment__metadata .attachment__name {
+    display: inline-block;
+    max-width: 100%;
+    vertical-align: bottom;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap; }
+  trix-editor .attachment__metadata .attachment__size {
+    margin-left: 0.2em;
+    white-space: nowrap; }
+
+.trix-content {
+  line-height: 1.5;
+  overflow-wrap: break-word;
+  word-break: break-word; }
+  .trix-content * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0; }
+  .trix-content h1 {
+    font-size: 1.2em;
+    line-height: 1.2; }
+  .trix-content blockquote {
+    border: 0 solid #ccc;
+    border-left-width: 0.3em;
+    margin-left: 0.3em;
+    padding-left: 0.6em; }
+  .trix-content [dir=rtl] blockquote,
+  .trix-content blockquote[dir=rtl] {
+    border-width: 0;
+    border-right-width: 0.3em;
+    margin-right: 0.3em;
+    padding-right: 0.6em; }
+  .trix-content li {
+    margin-left: 1em; }
+  .trix-content [dir=rtl] li {
+    margin-right: 1em; }
+  .trix-content pre {
+    display: inline-block;
+    width: 100%;
+    vertical-align: top;
+    font-family: monospace;
+    font-size: 0.9em;
+    padding: 0.5em;
+    white-space: pre;
+    background-color: #eee;
+    overflow-x: auto; }
+  .trix-content img {
+    max-width: 100%;
+    height: auto; }
+  .trix-content .attachment {
+    display: inline-block;
+    position: relative;
+    max-width: 100%; }
+    .trix-content .attachment a {
+      color: inherit;
+      text-decoration: none; }
+      .trix-content .attachment a:hover, .trix-content .attachment a:visited:hover {
+        color: inherit; }
+  .trix-content .attachment__caption {
+    text-align: center; }
+    .trix-content .attachment__caption .attachment__name + .attachment__size::before {
+      content: ' \2022 '; }
+  .trix-content .attachment--preview {
+    width: 100%;
+    text-align: center; }
+    .trix-content .attachment--preview .attachment__caption {
+      color: #666;
+      font-size: 0.9em;
+      line-height: 1.2; }
+  .trix-content .attachment--file {
+    color: #333;
+    line-height: 1;
+    margin: 0 2px 2px 2px;
+    padding: 0.4em 1em;
+    border: 1px solid #bbb;
+    border-radius: 5px; }
+  .trix-content .attachment-gallery {
+    display: flex;
+    flex-wrap: wrap;
+    position: relative; }
+    .trix-content .attachment-gallery .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%; }
+    .trix-content .attachment-gallery.attachment-gallery--2 .attachment, .trix-content .attachment-gallery.attachment-gallery--4 .attachment {
+      flex-basis: 50%;
+      max-width: 50%; }
+
+/*
+ * We need to override trix.css’s image gallery styles to accommodate the
+ * <action-text-attachment> element we wrap around attachments. Otherwise,
+ * images in galleries will be squished by the max-width: 33%; rule.
+*/
+.trix-content .attachment-gallery > action-text-attachment,
+.trix-content .attachment-gallery > .attachment {
+  flex: 1 0 33%;
+  padding: 0 0.5em;
+  max-width: 33%;
+}
+
+.trix-content .attachment-gallery.attachment-gallery--2 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--2 > .attachment, .trix-content .attachment-gallery.attachment-gallery--4 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--4 > .attachment {
+  flex-basis: 50%;
+  max-width: 50%;
+}
+
+.trix-content action-text-attachment .attachment {
+  padding: 0 !important;
+  max-width: 100% !important;
+}

--- a/app/controllers/member_informations_controller.rb
+++ b/app/controllers/member_informations_controller.rb
@@ -1,4 +1,16 @@
 class MemberInformationsController < ApplicationController
   def create
+    @member_information = MemberInformation.new(member_params)
+    if @member_information.save
+      redirect_to member_path(@member_information.member)
+    else
+      redirect_to member_path(@member_information.member)
+    end
+  end
+
+  private
+
+  def member_params
+    params.require(:member_information).permit(:content).merge(user_id: current_user.id, member_id: params[:member_id])
   end
 end

--- a/app/controllers/member_informations_controller.rb
+++ b/app/controllers/member_informations_controller.rb
@@ -1,0 +1,4 @@
+class MemberInformationsController < ApplicationController
+  def create
+  end
+end

--- a/app/controllers/member_informations_controller.rb
+++ b/app/controllers/member_informations_controller.rb
@@ -1,10 +1,16 @@
 class MemberInformationsController < ApplicationController
   def create
     @member_information = MemberInformation.new(member_params)
-    if @member_information.save
-      redirect_to member_path(@member_information.member)
-    else
-      redirect_to member_path(@member_information.member)
+    respond_to do |format|
+      if @member_information.save
+        @new_info = MemberInformation.new
+        @member = Member.find(params[:member_id])
+        @member_informations = @member.member_informations.includes(:user, :rich_text_content).order(created_at: :desc)
+        flash.now[:success] = I18n.t('flash.success.post')
+        format.turbo_stream { render 'members/turbo_stream/info_create' }
+      else
+        redirect_to member_path(@member_information.member)
+      end
     end
   end
 

--- a/app/controllers/member_informations_controller.rb
+++ b/app/controllers/member_informations_controller.rb
@@ -1,15 +1,17 @@
 class MemberInformationsController < ApplicationController
   def create
     @member_information = MemberInformation.new(member_params)
+    @member = Member.find(params[:member_id])
     respond_to do |format|
       if @member_information.save
         @new_info = MemberInformation.new
-        @member = Member.find(params[:member_id])
         @member_informations = @member.member_informations.includes(:user, :rich_text_content).order(created_at: :desc)
         flash.now[:success] = I18n.t('flash.success.post')
         format.turbo_stream { render 'members/turbo_stream/info_create' }
       else
-        redirect_to member_path(@member_information.member)
+        @new_info = @member_information
+        flash.now[:error] = I18n.t('flash.error.post')
+        format.turbo_stream { render 'members/turbo_stream/info_create_failure', status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -7,6 +7,7 @@ class MembersController < ApplicationController
     @member = Member.eager_load([instruments: [gears: :image_attachment]], :image_attachment).find(params[:id])
     sort_instruments(@member.instruments)
     @new_information = MemberInformation.new
+    @informations = @member.member_informations.includes(:user).order(created_at: :desc)
   end
 
   def image

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -6,6 +6,7 @@ class MembersController < ApplicationController
   def show
     @member = Member.eager_load([instruments: [gears: :image_attachment]], :image_attachment).find(params[:id])
     sort_instruments(@member.instruments)
+    @new_information = MemberInformation.new
   end
 
   def image

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -7,7 +7,7 @@ class MembersController < ApplicationController
     @member = Member.eager_load([instruments: [gears: :image_attachment]], :image_attachment).find(params[:id])
     sort_instruments(@member.instruments)
     @new_information = MemberInformation.new
-    @informations = @member.member_informations.includes(:user).order(created_at: :desc)
+    @informations = @member.member_informations.includes(:user, :rich_text_content).order(created_at: :desc)
   end
 
   def image

--- a/app/decorators/member_information_decorator.rb
+++ b/app/decorators/member_information_decorator.rb
@@ -1,0 +1,13 @@
+class MemberInformationDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/decorators/member_information_decorator.rb
+++ b/app/decorators/member_information_decorator.rb
@@ -9,5 +9,4 @@ class MemberInformationDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/helpers/member_informations_helper.rb
+++ b/app/helpers/member_informations_helper.rb
@@ -1,0 +1,2 @@
+module MemberInformationsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+import "trix"
+import "@rails/actiontext"

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -8,6 +8,8 @@ class Member < ApplicationRecord
   has_many :instruments, dependent: :destroy
   accepts_nested_attributes_for :instruments, allow_destroy: true
 
+  has_many :member_informations, dependent: :destroy
+
   enum :role, { member: 0, support: 1, staff: 2 }
   enum :blood_type, { A: 0, B: 1, O: 2, AB: 3 }
   enum :mbti,

--- a/app/models/member_information.rb
+++ b/app/models/member_information.rb
@@ -1,4 +1,6 @@
 class MemberInformation < ApplicationRecord
   belongs_to :member
   belongs_to :user
+
+  has_rich_text :content
 end

--- a/app/models/member_information.rb
+++ b/app/models/member_information.rb
@@ -3,4 +3,5 @@ class MemberInformation < ApplicationRecord
   belongs_to :user
 
   has_rich_text :content
+  validates :content, presence: true
 end

--- a/app/models/member_information.rb
+++ b/app/models/member_information.rb
@@ -1,0 +1,4 @@
+class MemberInformation < ApplicationRecord
+  belongs_to :member
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
   has_many :informations, as: :reportable, dependent: :destroy
   has_many :histories, dependent: :destroy
   has_many :likes, as: :likable, dependent: :destroy
+  has_many :member_informations, dependent: :destroy
 
   # Twitter認証ログイン用
   # ユーザーの情報があれば探し、無ければ作成する

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,0 +1,3 @@
+<div class="trix-content">
+  <%= yield -%>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="apple-touch-icon" href="favicon.ico">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "actiontext", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <script src="https://kit.fontawesome.com/03ee00071c.js" crossorigin="anonymous"></script>
     <%= display_meta_tags(default_meta_tags) %>

--- a/app/views/members/_information.html.erb
+++ b/app/views/members/_information.html.erb
@@ -1,0 +1,1 @@
+<%= info.content %>

--- a/app/views/members/_information.html.erb
+++ b/app/views/members/_information.html.erb
@@ -1,1 +1,14 @@
-<%= info.content %>
+<div class="card bg-base-100 w-full shadow-xl mb-3">
+  <div class="card-body">
+    <div class="avatar flex items-center">
+      <div class="w-4 md:w-6 rounded-full mr-1 md:mr-2">
+        <img src="<%= info.user.image %>" />
+      </div>
+      <h3 class="text-xs	md:text-base mr-1"><%= info.user.name.truncate(10) %></h3>
+      <p class="font-light text-slate-300 text-xs	md:text-base">（<%= time_ago_in_words(info.created_at) %>前）</p>
+    </div>
+    <h2 class="card-title text-base md:text-lg"><%= info.content %></h2>
+    <div>
+    </div>
+  </div>
+</div>

--- a/app/views/members/_information_form.html.erb
+++ b/app/views/members/_information_form.html.erb
@@ -1,4 +1,15 @@
 <%= form_with model: info, url: member_member_informations_path(member_id: member.id), local: true do |f| %>
-  <%= f.rich_text_area :content, class: "h-full w-full" %>
-  <%= f.submit "送信", class: "btn btn-primary" %>
+  <div class="card shadow-2xl mb-5">
+    <div class="card-body">
+      <div class="flex">
+        <h2 class="card-title text-base	md:text-xl mb-3">自由に書き込んでください👍</h2>
+        <%#= render partial: "modal" %>
+      </div>
+      <%= render 'shared/error_messages', model: f.object %>
+      <%= f.rich_text_area :content, class: "h-full w-full" %>
+      <div class="card-actions justify-end">
+        <%= f.submit '投稿', class: "btn btn-primary mt-3" %>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/members/_information_form.html.erb
+++ b/app/views/members/_information_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: info, url: member_member_informations_path(member_id: member.id), local: true do |f| %>
+  <%= f.rich_text_area :content, class: "h-full w-full" %>
+  <%= f.submit "送信", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/members/_information_form.html.erb
+++ b/app/views/members/_information_form.html.erb
@@ -1,15 +1,17 @@
-<%= form_with model: info, url: member_member_informations_path(member_id: member.id), local: true do |f| %>
-  <div class="card shadow-2xl mb-5">
-    <div class="card-body">
-      <div class="flex">
-        <h2 class="card-title text-base	md:text-xl mb-3">自由に書き込んでください👍</h2>
-        <%#= render partial: "modal" %>
-      </div>
-      <%= render 'shared/error_messages', model: f.object %>
-      <%= f.rich_text_area :content, class: "h-full w-full" %>
-      <div class="card-actions justify-end">
-        <%= f.submit '投稿', class: "btn btn-primary mt-3" %>
+<%= turbo_frame_tag "information_form" do %>
+  <%= form_with model: info, url: member_member_informations_path(member_id: member.id), local: true do |f| %>
+    <div class="card shadow-2xl mb-5">
+      <div class="card-body">
+        <div class="flex">
+          <h2 class="card-title text-base	md:text-xl mb-3">自由に書き込んでください👍</h2>
+          <%#= render partial: "modal" %>
+        </div>
+        <%= render 'shared/error_messages', model: f.object %>
+        <%= f.rich_text_area :content, class: "h-full w-full" %>
+        <div class="card-actions justify-end">
+          <%= f.submit '投稿', class: "btn btn-primary mt-3" %>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/members/_informations.html.erb
+++ b/app/views/members/_informations.html.erb
@@ -1,0 +1,3 @@
+<% infos.each do |info| %>
+  <%= render partial: "members/information", locals: { info: info } %>
+<% end %>

--- a/app/views/members/_informations.html.erb
+++ b/app/views/members/_informations.html.erb
@@ -1,3 +1,5 @@
-<% infos.each do |info| %>
-  <%= render partial: "members/information", locals: { info: info } %>
-<% end %>
+<div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-5">
+  <% infos.each do |info| %>
+    <%= render partial: "members/information", locals: { info: info } %>
+  <% end %>
+</div>

--- a/app/views/members/_informations.html.erb
+++ b/app/views/members/_informations.html.erb
@@ -1,5 +1,7 @@
-<div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-5">
-  <% infos.each do |info| %>
-    <%= render partial: "members/information", locals: { info: info } %>
-  <% end %>
-</div>
+<%= turbo_frame_tag 'informations' do %>
+  <div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-5">
+    <% infos.each do |info| %>
+      <%= render partial: "members/information", locals: { info: info } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -110,4 +110,5 @@
     <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">メンバー情報</h2>
   </div>
   <%= render partial: "members/information_form", locals: { member: @member, info: @new_information } %>
+  <%= render partial: "members/informations", locals: { infos: @informations } %>
 </div>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -105,4 +105,9 @@
       </div>
     </ul>
   </div>
+
+  <div class="divider mb-5">
+    <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">メンバー情報</h2>
+  </div>
+  <%= render partial: "members/information_form", locals: { member: @member, info: @new_information } %>
 </div>

--- a/app/views/members/turbo_stream/info_create.turbo_stream.erb
+++ b/app/views/members/turbo_stream/info_create.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.replace "information_form" do %>
+  <%= render partial: "members/information_form", locals: { member: @member, info: @new_info } %>
+<% end %>
+
+<%= turbo_stream.replace "informations" do %>
+  <%= render partial: "members/informations", locals: { infos: @member_informations } %>
+<% end %>
+
+<%= turbo_stream.replace "flash_message" do %>
+  <%= render partial: "shared/flash_messages" %>
+<% end %>

--- a/app/views/members/turbo_stream/info_create_failure.turbo_stream.erb
+++ b/app/views/members/turbo_stream/info_create_failure.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%= turbo_stream.replace "information_form" do %>
+  <%= render partial: "members/information_form", locals: { member: @member, info: @new_info } %>
+<% end %>
+
+
+<%= turbo_stream.replace "flash_message" do %>
+  <%= render partial: "shared/flash_messages" %>
+<% end %>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -13,6 +13,8 @@ ja:
         remark: 説明
         date: 日付
         image: 画像
+      member_information:
+        content: コメント
       setlistitem_information:
         body: コメント
       event_information:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,10 @@ Rails.application.routes.draw do
   resources :notices, only: [:index]
   delete "notices" => "notices#destroy"
 
-  resources :members, only: [:index, :show]
+  resources :members, only: [:index, :show] do
+    resources :member_informations, only: [:create], shallow: true
+  end
+
   resources :histories, only: [:index, :new, :create, :show, :destroy, :edit, :update] do
     post "image/destroy" => "images#history_image_destroy"
     resources :informations, only: [:create], module: :histories

--- a/db/migrate/20250119035446_create_member_informations.rb
+++ b/db/migrate/20250119035446_create_member_informations.rb
@@ -1,0 +1,10 @@
+class CreateMemberInformations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :member_informations do |t|
+      t.integer :user_id, null: false
+      t.integer :member_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250119040005_create_action_text_tables.action_text.rb
+++ b/db/migrate/20250119040005_create_action_text_tables.action_text.rb
@@ -1,0 +1,26 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :action_text_rich_texts, id: primary_key_type do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_18_064425) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_19_035446) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -256,6 +256,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_18_064425) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", default: "title"
+  end
+
+  create_table "member_informations", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "member_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "members", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_19_035446) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_19_040005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.12",
+    "@rails/actiontext": "^8.0.100",
     "@stimulus-components/dialog": "^1.0.1",
     "@stimulus-components/notification": "^3.0.0",
     "@stimulus-components/rails-nested-form": "^5.0.0",
@@ -19,6 +20,7 @@
     "daisyui": "^4.12.13",
     "postcss": "^8.4.47",
     "stimulus-autocomplete": "^3.1.0",
-    "tailwindcss": "^3.4.14"
+    "tailwindcss": "^3.4.14",
+    "trix": "^2.1.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,6 +220,20 @@
   resolved "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.2.101.tgz"
   integrity sha512-YgFCyD+9mBhpJdfgf4QtJwk+vZbByVMXsEGREM6GrPk9A1pYXkkIpzYd3+843E+33e3S81yywhqZc3DyrZGPSg==
 
+"@rails/actiontext@^8.0.100":
+  version "8.0.100"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-8.0.100.tgz#251d7c2aa0747541897c6dd805147eadf4fa162f"
+  integrity sha512-/Q1m6owfmRsVQ6xL/pyRtJiSgQxE3LMsqVk5/6d+H7om5E9xmjZNr2fGy5n3PZfrpAuJhFjWZZjTPLYrMqTaKA==
+  dependencies:
+    "@rails/activestorage" ">= 8.0.0-alpha"
+
+"@rails/activestorage@>= 8.0.0-alpha":
+  version "8.0.100"
+  resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-8.0.100.tgz#a04f84b8e2359dce5c9cac0d2f408cd530d1495a"
+  integrity sha512-/fIFav9RFFzQKK3a91O2OOdnHxPx+mBIR6wZDxeH9bcbDf2dZqhVcr5DGRJuhkF8U7C3s0tYvYafscmkBNRlHQ==
+  dependencies:
+    spark-md5 "^3.0.1"
+
 "@stimulus-components/dialog@^1.0.1":
   version "1.0.1"
   resolved "https://registry.npmjs.org/@stimulus-components/dialog/-/dialog-1.0.1.tgz"
@@ -236,6 +250,11 @@
   version "5.0.0"
   resolved "https://registry.npmjs.org/@stimulus-components/rails-nested-form/-/rails-nested-form-5.0.0.tgz"
   integrity sha512-qrmmurT+KBPrz9iBlyrgJa6Di8i0j328kSk2SUR53nK5W0kDhw1YxVC91aUR+7EsFKiwJT1iB7oDSwpDhDQPeA==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -411,6 +430,13 @@ dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
+dompurify@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.3.tgz#05dd2175225324daabfca6603055a09b2382a4cd"
+  integrity sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -859,6 +885,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+spark-md5@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
+  integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
+
 stimulus-autocomplete@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz"
@@ -983,6 +1014,13 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+trix@^2.1.12:
+  version "2.1.12"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-2.1.12.tgz#102306c3a90afcc5b66815ce8d631ee43048a477"
+  integrity sha512-0hQvJdy257XuzRdCzSQ/QvcqyTp+8ixMxVLWxSbWvEzD2kgKFlcrMjgWZbtVkJENaod+jm2sBTOWAZVNWK+DMA==
+  dependencies:
+    dompurify "^3.2.3"
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"


### PR DESCRIPTION
## 概要
メンバーインフォの投稿フォームの作成、一覧表示を行いました。

## 加えた変更
* ActionTextの導入
  参考記事1：[大まかな導入手順](https://qiita.com/taiki-nd/items/556b804fc367ba30ca15)
  参考記事2：[Tailwindとの互換性解消](https://qiita.com/MIDO-ruby7/items/fd2c31ba00d8420cf630)
* 投稿フォームの作成
  <img width="493" alt="スクリーンショット 2025-01-20 11 37 14" src="https://github.com/user-attachments/assets/0d49734f-5e1b-4e57-8355-b35160521dd4" />
* 投稿成功・失敗時のフラッシュメッセージ等表示
  [![Image from Gyazo](https://i.gyazo.com/3c745ce04727aa8ca0e8b5276cb6b412.gif)](https://gyazo.com/3c745ce04727aa8ca0e8b5276cb6b412)
* 投稿された情報の一覧表示
  （スマホ画面）
  <img width="424" alt="スクリーンショット 2025-01-20 11 38 52" src="https://github.com/user-attachments/assets/c96edb98-4258-41ef-84d8-96b23038f0c5" />
  （タブレット）
  <img width="744" alt="スクリーンショット 2025-01-20 11 39 59" src="https://github.com/user-attachments/assets/2353f481-dc6f-408d-98cf-6c918d9c31c5" />
  （PC画面）
  <img width="920" alt="スクリーンショット 2025-01-20 11 39 40" src="https://github.com/user-attachments/assets/bbbea8a6-5857-4185-a687-ac5b462b50db" />


## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #24 