### PR TITLE
【WIP】Fix 各詳細ページのレスポンシブ対応実施

### DIFF
--- a/app/controllers/discs_controller.rb
+++ b/app/controllers/discs_controller.rb
@@ -1,7 +1,8 @@
 class DiscsController < ApplicationController
   def show
     @disc = Disc.includes(link_contents: :link).find(params[:id])
-    @link_contents = @disc.link_contents
+    @youtube_contents = @disc.links.where(platform: "YouTube").or(@disc.links.where(platform: "YouTubeMusic"))
+    @tiktok_contents = @disc.links.where(platform: "TikTok")
     @disc_versions = DiscVersion.includes(:disc).where(disc_id: params[:id])
     @disc_contents = DiscContent.includes(:event, disc_version: :disc).where(disc: { id: params[:id] }).order(:id)
     @disc_items = DiscItem.includes(:song, disc_content: [:event, { disc_version: :disc }]).where(disc: { id: params[:id] })

--- a/app/controllers/event_informations_controller.rb
+++ b/app/controllers/event_informations_controller.rb
@@ -1,14 +1,14 @@
 class EventInformationsController < ApplicationController
   def create
     @info = EventInformation.new(event_information_params)
+    @event = Event.find(params[:event_id])
     respond_to do |format|
       if @info.save
+        @infos = EventInformation.eager_load(:user, :likes_on_event_informations).where(event_id: @event.id).order(created_at: :desc)
         @new_info = EventInformation.new
-        @event = Event.find(params[:event_id])
         flash.now[:success] = I18n.t('flash.success.post')
         format.turbo_stream { render 'create' }
       else
-        @event = Event.includes(:setlist).find(params[:event_id])
         @new_info = @info
         flash.now[:error] = I18n.t('flash.error.post')
         format.turbo_stream { render 'create_failure', status: :unprocessable_entity }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -24,7 +24,7 @@ class EventsController < ApplicationController
     @setlistitems = Setlistitem.where(setlist_id: @event.setlist.id)
     @infos = []
     @setlistitems.each do |item|
-      @infos << SetlistitemInformation.where(setlistitem_id: item.id).order(created_at: :desc)
+      @infos << SetlistitemInformation.eager_load(:user, :likes_on_setlistitem_informations).where(setlistitem_id: item.id).order(created_at: :desc)
     end
     @infos.flatten!
     @setlistitem_new_info = SetlistitemInformation.new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,8 +12,9 @@ class EventsController < ApplicationController
   end
 
   def show
-    @event = Event.includes([:setlist, { link_contents: :link }]).find(params[:id])
-    @link_contents = @event.link_contents
+    @event = Event.includes(:setlist).find(params[:id])
+    @youtube_contents = @event.links.where(platform: "YouTube").or(@event.links.where(platform: "YouTubeMusic"))
+    @tiktok_contents = @event.links.where(platform: "TikTok")
     @disc_contents = DiscContent.includes(:event, disc_version: :disc).where(event_id: params[:id])
     @info = EventInformation.new
     @event_infomations = EventInformation.includes([:user, :likes_on_event_informations])

--- a/app/controllers/likes_on_event_informations_controller.rb
+++ b/app/controllers/likes_on_event_informations_controller.rb
@@ -3,15 +3,17 @@ class LikesOnEventInformationsController < ApplicationController
     event_information = EventInformation.find(params[:event_information_id])
     likes_on_event_information = current_user.likes_on_event_informations.new(event_information_id: event_information.id)
     likes_on_event_information.save
-    # respond_to do |format|
-    #   format.turbo_stream { render '', locals: {  } }
-    # end
+    respond_to do |format|
+      format.turbo_stream { render 'event_informations/like', locals: { event_information: event_information } }
+    end
   end
 
   def destroy
     event_information = EventInformation.find(params[:event_information_id])
     likes_on_event_information = current_user.likes_on_event_informations.find_by(event_information_id: event_information.id)
     likes_on_event_information.destroy
-    redirect_to event_path(id: event_information.event.id)
+    respond_to do |format|
+      format.turbo_stream { render 'event_informations/unlike', locals: { event_information: event_information } }
+    end
   end
 end

--- a/app/controllers/likes_on_event_informations_controller.rb
+++ b/app/controllers/likes_on_event_informations_controller.rb
@@ -3,7 +3,9 @@ class LikesOnEventInformationsController < ApplicationController
     event_information = EventInformation.find(params[:event_information_id])
     likes_on_event_information = current_user.likes_on_event_informations.new(event_information_id: event_information.id)
     likes_on_event_information.save
-    redirect_to event_path(id: event_information.event.id)
+    # respond_to do |format|
+    #   format.turbo_stream { render '', locals: {  } }
+    # end
   end
 
   def destroy

--- a/app/controllers/likes_on_setlistitem_informations_controller.rb
+++ b/app/controllers/likes_on_setlistitem_informations_controller.rb
@@ -4,7 +4,9 @@ class LikesOnSetlistitemInformationsController < ApplicationController
     likes_on_setlistitem_information =
       current_user.likes_on_setlistitem_informations.new(setlistitem_information_id: setlistitem_information.id)
     likes_on_setlistitem_information.save
-    redirect_to event_path(id: setlistitem_information.setlistitem.setlist.event.id)
+    respond_to do |format|
+      format.turbo_stream { render 'setlistitem_informations/like', locals: { setlistitem_info: setlistitem_information } }
+    end
   end
 
   def destroy
@@ -12,6 +14,8 @@ class LikesOnSetlistitemInformationsController < ApplicationController
     likes_on_setlistitem_information =
       current_user.likes_on_setlistitem_informations.find_by(setlistitem_information_id: setlistitem_information.id)
     likes_on_setlistitem_information.destroy
-    redirect_to event_path(id: setlistitem_information.setlistitem.setlist.event.id)
+    respond_to do |format|
+      format.turbo_stream { render 'setlistitem_informations/like', locals: { setlistitem_info: setlistitem_information } }
+    end
   end
 end

--- a/app/controllers/setlistitem_informations_controller.rb
+++ b/app/controllers/setlistitem_informations_controller.rb
@@ -4,6 +4,7 @@ class SetlistitemInformationsController < ApplicationController
     @item = Setlistitem.find(@info.setlistitem_id)
     respond_to do |format|
       if @info.save
+        @infos = SetlistitemInformation.where(setlistitem_id: @item.id).order(created_at: :desc)
         @setlistitem_new_info = SetlistitemInformation.new
         flash.now[:success] = I18n.t('flash.success.post')
         format.turbo_stream

--- a/app/controllers/setlistitem_informations_controller.rb
+++ b/app/controllers/setlistitem_informations_controller.rb
@@ -4,7 +4,7 @@ class SetlistitemInformationsController < ApplicationController
     @item = Setlistitem.find(@info.setlistitem_id)
     respond_to do |format|
       if @info.save
-        @infos = SetlistitemInformation.where(setlistitem_id: @item.id).order(created_at: :desc)
+        @infos = SetlistitemInformation.eager_load(:user, :likes_on_setlistitem_informations).where(setlistitem_id: @item.id).order(created_at: :desc)
         @setlistitem_new_info = SetlistitemInformation.new
         flash.now[:success] = I18n.t('flash.success.post')
         format.turbo_stream

--- a/app/controllers/song_informations_controller.rb
+++ b/app/controllers/song_informations_controller.rb
@@ -5,6 +5,7 @@ class SongInformationsController < ApplicationController
     respond_to do |format|
       if @info.save
         @new_song_information = SongInformation.new
+        @song_informations = SongInformation.where(song_id: params[:song_id]).order(created_at: :desc)
         flash.now[:success] = I18n.t('flash.success.post')
         format.turbo_stream
       else

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -7,8 +7,9 @@ class SongsController < ApplicationController
   end
 
   def show
-    @song = Song.includes(link_contents: :link).find(params[:id])
-    @link_contents = @song.link_contents
+    @song = Song.find(params[:id])
+    @youtube_contents = @song.links.where(platform: "YouTube").or(@song.links.where(platform: "YouTubeMusic"))
+    @tiktok_contents = @song.links.where(platform: "TikTok")
     @new_song_information = SongInformation.new
     @song_informations = @song.song_informations.includes(:user, :likes_on_song_informations).order(created_at: :desc)
     @events = Event.includes(setlist: :setlistitems).where(setlistitems: { song_id: params[:id] }).order(:date)

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -10,7 +10,7 @@ class SongsController < ApplicationController
     @song = Song.includes(link_contents: :link).find(params[:id])
     @link_contents = @song.link_contents
     @new_song_information = SongInformation.new
-    @song_informations = @song.song_informations.includes(:user).order(created_at: :desc)
+    @song_informations = @song.song_informations.includes(:user, :likes_on_song_informations).order(created_at: :desc)
     @events = Event.includes(setlist: :setlistitems).where(setlistitems: { song_id: params[:id] }).order(:date)
     @song_disc_items = DiscItem.includes(disc_content: { disc_version: :disc })
                                .where(disc_contents: { content_type: 0 },

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,7 +6,7 @@ class Event < ApplicationRecord
   has_one :setlist, dependent: :destroy
 
   has_many :link_contents, as: :linkable, dependent: :destroy
-  has_many :links, dependent: :destroy, through: :link_contents
+  has_many :links, through: :link_contents
   accepts_nested_attributes_for :link_contents, allow_destroy: true
 
   has_one_attached :visual_image

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,7 +6,7 @@ class Event < ApplicationRecord
   has_one :setlist, dependent: :destroy
 
   has_many :link_contents, as: :linkable, dependent: :destroy
-  has_many :links, through: :link_contents
+  has_many :links, dependent: :destroy, through: :link_contents
   accepts_nested_attributes_for :link_contents, allow_destroy: true
 
   has_one_attached :visual_image

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,5 +1,6 @@
 class Link < ApplicationRecord
   has_many :link_contents, dependent: :destroy
+  has_many :links, dependent: :destroy, through: :link_contents
   has_many :link_dates, dependent: :destroy
   accepts_nested_attributes_for :link_dates, allow_destroy: true
 

--- a/app/views/discs/jacket.html.erb
+++ b/app/views/discs/jacket.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="jacket_<%= @disc_version.id %>">
-  <div class="my-3 flex">
-    <% if @disc_version.jacket.attached? %>
-      <%= image_tag @disc_version.jacket.variant(resize_to_limit: [300, 300]), class: "w-1/2 md:w-1/3" %>
-    <% end %>
-  </div>
+  <% if @disc_version.jacket.attached? %>
+    <%= image_tag @disc_version.jacket.variant(resize_to_limit: [300, 300]), class: "" %>
+  <% else %>
+    <%= image_tag 'default_people_1.jpg', class: "" %>
+  <% end %>
 </turbo-frame>

--- a/app/views/discs/show.html.erb
+++ b/app/views/discs/show.html.erb
@@ -35,7 +35,7 @@
     </div>
   </div>
 
-  <%= render partial: "links/links", locals: { link_contents: @link_contents } %>
+  <%= render partial: "links/links", locals: { youtubes: @youtube_contents, tiktoks: @tiktok_contents } %>
 
   <div>
     <div class="divider mb-5">

--- a/app/views/event_informations/_event_information.html.erb
+++ b/app/views/event_informations/_event_information.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag event_information do %>
-  <div class="card bg-base-100 w-full shadow-xl mb-3">
+  <div class="card bg-base-100 w-full h-full shadow-xl mb-3">
     <div class="card-body">
       <div class="avatar flex items-center">
         <div class="w-4 md:w-6 rounded-full mr-1 md:mr-2">

--- a/app/views/event_informations/_event_information.html.erb
+++ b/app/views/event_informations/_event_information.html.erb
@@ -5,7 +5,7 @@
         <div class="w-4 md:w-6 rounded-full mr-1 md:mr-2">
           <img src="<%= event_information.user.image %>" />
         </div>
-        <h3 class="text-xs	md:text-base mr-1"><%= event_information.user.name %></h3>
+        <h3 class="text-xs	md:text-base mr-1"><%= event_information.user.name.truncate(16) %></h3>
         <p class="font-light text-slate-300 text-xs	md:text-base">（<%= time_ago_in_words(event_information.created_at) %>前）</p>
       </div>
       <h2 class="card-title text-base md:text-lg"><%= event_information.body %></h2>

--- a/app/views/event_informations/_event_information.html.erb
+++ b/app/views/event_informations/_event_information.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag event_information do %>
+<%= turbo_frame_tag "event_information" do %>
   <div class="card bg-base-100 w-full h-full shadow-xl mb-3">
     <div class="card-body">
       <div class="avatar flex items-center">
@@ -11,7 +11,9 @@
       <h2 class="card-title text-base md:text-lg"><%= event_information.body %></h2>
       <div>
         <% if user_signed_in? %>
-          <%= render partial: "events/info_fav_btn", locals: {event_information: event_information} %>
+          <%= turbo_frame_tag "like_on_event_info_#{event_information.id}" do %>
+            <%= render partial: "events/info_fav_btn", locals: {event_information: event_information} %>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/event_informations/_event_informations.html.erb
+++ b/app/views/event_informations/_event_informations.html.erb
@@ -1,3 +1,5 @@
-<% event_informations.each do |info| %>
-  <%= render partial: "event_informations/event_information", locals: {event_information: info} %>
-<% end %>
+<div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-3">
+  <% event_informations.each do |info| %>
+    <%= render partial: "event_informations/event_information", locals: {event_information: info} %>
+  <% end %>
+</div>

--- a/app/views/event_informations/create.turbo_stream.erb
+++ b/app/views/event_informations/create.turbo_stream.erb
@@ -2,8 +2,8 @@
   <%= render partial: "form", locals: { event: @event, info: @new_info } %>
 <% end %>
 
-<%= turbo_stream.prepend "event_informations" do %>
-  <%= render partial: "event_informations/event_information", locals: { event_information: @info } %>
+<%= turbo_stream.update "event_informations" do %>
+  <%= render partial: "event_informations/event_informations", locals: { event_informations: @infos } %>
 <% end %>
 
 <%= turbo_stream.replace "flash_message" do %>

--- a/app/views/event_informations/like.turbo_stream.erb
+++ b/app/views/event_informations/like.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "like_on_event_info_#{event_information.id}" do %>
+  <%= render partial: "events/info_fav_btn", locals: { event_information: event_information } %>
+<% end %>

--- a/app/views/event_informations/unlike.turbo_stream.erb
+++ b/app/views/event_informations/unlike.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "like_on_event_info_#{event_information.id}" do %>
+  <%= render partial: "events/info_fav_btn", locals: { event_information: event_information } %>
+<% end %>

--- a/app/views/events/_info_fav_btn.html.erb
+++ b/app/views/events/_info_fav_btn.html.erb
@@ -4,12 +4,12 @@
       <%= link_to event_information_likes_on_event_informations_path(event_information), data: { "turbo-method": :delete } do %>
         <i class="fa-solid fa-heart"></i>
       <% end %>
-      <%= event_information.likes_on_event_informations.count %> いいね
+      <%= event_information.likes_on_event_informations.length %> いいね
     <% else %>
       <%= link_to event_information_likes_on_event_informations_path(event_information), data: { "turbo-method": :post } do %>
         <i class="fa-regular fa-heart"></i>
       <% end %>
-      <%= event_information.likes_on_event_informations.count %> いいね
+      <%= event_information.likes_on_event_informations.length %> いいね
     <% end %>
   <% end %>
 </div>

--- a/app/views/events/_info_fav_btn.html.erb
+++ b/app/views/events/_info_fav_btn.html.erb
@@ -1,15 +1,13 @@
 <div class="text-sm md:text-base">
-  <%= turbo_frame_tag event_information do %>
-    <% if event_information.liked_by?(current_user) %>
-      <%= link_to event_information_likes_on_event_informations_path(event_information), data: { "turbo-method": :delete } do %>
-        <i class="fa-solid fa-heart"></i>
-      <% end %>
-      <%= event_information.likes_on_event_informations.length %> いいね
-    <% else %>
-      <%= link_to event_information_likes_on_event_informations_path(event_information), data: { "turbo-method": :post } do %>
-        <i class="fa-regular fa-heart"></i>
-      <% end %>
-      <%= event_information.likes_on_event_informations.length %> いいね
+  <% if event_information.liked_by?(current_user) %>
+    <%= link_to event_information_likes_on_event_informations_path(event_information), data: { "turbo-method": :delete } do %>
+      <i class="fa-solid fa-heart"></i>
     <% end %>
+    <%= event_information.likes_on_event_informations.length %> いいね
+  <% else %>
+    <%= link_to event_information_likes_on_event_informations_path(event_information), data: { "turbo-method": :post } do %>
+      <i class="fa-regular fa-heart"></i>
+    <% end %>
+    <%= event_information.likes_on_event_informations.length %> いいね
   <% end %>
 </div>

--- a/app/views/events/_setlistitem.html.erb
+++ b/app/views/events/_setlistitem.html.erb
@@ -1,7 +1,7 @@
 <% setlistitems.each do |item| %>
   <div class="collapse collapse-arrow border-base-300 border mb-5 bg-base-300 z-10">
     <input type="checkbox" name="my-accordion-4" class="w-full" />
-    <div class="collapse-title text-base md:text-xl">
+    <div class="collapse-title text-base md:text-xl md:px-8">
       <%= song_display(item) %>
     </div>
     <div class="collapse-content w-full">

--- a/app/views/events/_setlistitem.html.erb
+++ b/app/views/events/_setlistitem.html.erb
@@ -1,6 +1,6 @@
 <% setlistitems.each do |item| %>
   <div class="collapse collapse-arrow border-base-300 border mb-5 bg-base-300 z-10">
-    <input type="radio" name="my-accordion-4" class="w-full" />
+    <input type="checkbox" name="my-accordion-4" class="w-full" />
     <div class="collapse-title text-base md:text-xl">
       <%= song_display(item) %>
     </div>

--- a/app/views/events/_setlistitem.html.erb
+++ b/app/views/events/_setlistitem.html.erb
@@ -11,7 +11,7 @@
         </div>
       <% end %>
       <%= render partial: 'setlistitem_informations/form', locals: {item: item} %>
-      <%= render partial: 'setlistitem_informations/setlistitem_informations', locals: {item: item, infos: infos} %>
+      <%= render partial: 'setlistitem_informations/setlistitem_informations', locals: {item: item, infos: infos.select{|i| i.setlistitem_id == item.id}} %>
     </div>
   </div>
 <% end %>

--- a/app/views/events/_setlistitem.html.erb
+++ b/app/views/events/_setlistitem.html.erb
@@ -1,19 +1,17 @@
 <% setlistitems.each do |item| %>
-  <div class="join join-vertical w-full">
-    <div class="collapse collapse-arrow join-item border-base-300 border mb-5 bg-base-300">
-      <input type="radio" name="my-accordion-4" />
-      <div class="collapse-title text-base md:text-xl font-medium">
-        <%= song_display(item) %>
-      </div>
-      <div class="collapse-content w-full">
-        <% if item.song_id.present? %>
-          <div class="mb-5">
-            <%= link_to "楽曲の詳細を見る", song_path(id: item.song_id), class: "link" %>
-          </div>
-        <% end %>
-        <%= render partial: 'setlistitem_informations/form', locals: {item: item} %>
-        <%= render partial: 'setlistitem_informations/setlistitem_informations', locals: {item: item, infos: infos} %>
-      </div>
+  <div class="collapse collapse-arrow border-base-300 border mb-5 bg-base-300 z-10">
+    <input type="radio" name="my-accordion-4" class="w-full" />
+    <div class="collapse-title text-base md:text-xl">
+      <%= song_display(item) %>
+    </div>
+    <div class="collapse-content w-full">
+      <% if item.song_id.present? %>
+        <div class="mb-5">
+          <%= link_to "楽曲の詳細を見る", song_path(id: item.song_id), class: "link" %>
+        </div>
+      <% end %>
+      <%= render partial: 'setlistitem_informations/form', locals: {item: item} %>
+      <%= render partial: 'setlistitem_informations/setlistitem_informations', locals: {item: item, infos: infos} %>
     </div>
   </div>
 <% end %>

--- a/app/views/events/_setlistitem.html.erb
+++ b/app/views/events/_setlistitem.html.erb
@@ -11,7 +11,9 @@
         </div>
       <% end %>
       <%= render partial: 'setlistitem_informations/form', locals: {item: item} %>
-      <%= render partial: 'setlistitem_informations/setlistitem_informations', locals: {item: item, infos: infos.select{|i| i.setlistitem_id == item.id}} %>
+      <%= turbo_frame_tag "setlistitem_#{item.id}_infos" do %>
+        <%= render partial: 'setlistitem_informations/setlistitem_informations', locals: {item: item, infos: infos.select{|i| i.setlistitem_id == item.id}} %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/events/image.html.erb
+++ b/app/views/events/image.html.erb
@@ -2,6 +2,6 @@
   <% if @event.visual_image.attached? %>
     <%= image_tag @event.visual_image.variant(resize_to_fill: [600, 600], format: :webp), class: "object-cover " %>
   <% else %>
-    <%= image_tag 'default_people_1.jpg', class: "object-cover mb-10" %>
+    <%= image_tag 'default_people_1.jpg', class: "object-cover " %>
   <% end %>
 </turbo-frame>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -58,16 +58,28 @@
       <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">収録情報</h2>
     </div>
     <% if @disc_contents.present? %>
-      <ul>
+      <div class="grid grid-cols-1 md:grid-cols-2">
         <% @disc_contents.each do |content| %>
-          <li>
-            <%= link_to disc_path(content.disc_version.disc.id), class: "link link-primary" do %>
-              <%= content.disc_version.disc.title %>
-              （<%= t("activerecord.attributes.disc_version.#{content.disc_version.version}") %>）
-            <% end %>
-          </li>
+          <div class="mx-3">
+            <div class="h-32 md:h-40 w-full my-2 flex justify-center">
+              <%= link_to disc_path(content.disc_version.disc), class: "w-32 h-full md:w-40" do %>
+                <turbo-frame id="jacket_<%= content.disc_version.id %>" src="/version_jacket/<%= content.disc_version.id %>" loading="lazy">
+                  <div class="skeleton w-full h-full flex items-center justify-center">
+                    <span class="loading loading-spinner loading-xs"></span>
+                  </div>
+                </turbo_frame>
+              <% end %>
+            </div>
+            <p class="text-xs text-center mb-2">
+              <%= link_to disc_path(content.disc_version.disc_id), class: "link link-primary" do %>
+                <%= content.disc_version.disc.title %><br>
+                （<%= t("activerecord.attributes.disc_version.#{content.disc_version.version}") %>）<br>
+              <% end %>
+            </p>
+          </div>
         <% end %>
-        <p>に収録されているヨ！</p>
+      </div>
+      <p class="text-center">に収録されています！</p>
     <% else %>
       <p class="text-center">😑この日の映像は発売されてないヨ😑</p>
     <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -14,8 +14,8 @@
     </div>
   <% end %>
 
-  <div>
-    <div class="mb-5">
+  <div class="md:grid md:grid-cols-3 md:gap-4">
+    <div class="mb-5 md:col-span-2">
       <div class="divider mb-5">
         <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">概要</h2>
       </div>
@@ -41,7 +41,7 @@
       </div>
     </div>
 
-    <div class="mb-8">
+    <div class="mb-5">
       <div class="divider mb-5">
         <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">収録情報</h2>
       </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -25,13 +25,25 @@
       <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">概要</h2>
     </div>
     </h1>
-    <p>
-    日時：<%= I18n.l(@event.date, format: "%Y/%m/%d(%a)") %><br>
-    会場：<%= t("activerecord.attributes.event.place_prefecture.#{@event.place_prefecture}") %> <%= @event.place %><br>
+    <div class="text-sm md:text-base">
+      <div class="flex items-center">
+        <i class="fa-solid fa-calendar-days mr-1"></i>
+        <p>
+          <%= I18n.l(@event.date, format: "%Y/%m/%d(%a)") %>
+        </p>
+      </div>
+      <div class="flex items-center">
+        <i class="fa-solid fa-location-dot mr-1"></i>
+        <p>
+          <%= t("activerecord.attributes.event.place_prefecture.#{@event.place_prefecture}") %> <%= @event.place %>
+        </p>
+      </div>
       <% if @event.remark.present? %>
-        備考：<%= @event.remark %>
+        <div class="flex items-start mt-3">
+          <%= @event.remark %>
+        </div>
       <% end %>
-    </p>
+    </div>
   </div>
 
 
@@ -82,7 +94,7 @@
     <%= link_to "セットリストを投稿", new_event_setlist_path(params[:id]), class: 'btn btn-primary mb-5' %>
   <% end %>
 
-  <%= render partial: "links/links", locals: { link_contents: @link_contents } %>
+  <%= render partial: "links/links", locals: { youtubes: @youtube_contents, tiktoks: @tiktok_contents } %>
 
   <%= render 'events/information_index', event_informations: @event_infomations %>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,25 +16,25 @@
 
   <div class="md:grid md:grid-cols-3 md:gap-4">
     <div class="mb-5 md:col-span-2">
-      <div class="divider mb-5">
+      <div class="divider mb-5 lg:mb-8">
         <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">概要</h2>
       </div>
       </h1>
-      <div class="text-sm md:text-base">
-        <div class="flex items-center">
-          <i class="fa-solid fa-calendar-days mr-1"></i>
+      <div class="text-sm md:text-lg lg:text-xl">
+        <div class="flex items-center justify-center">
+          <i class="fa-solid fa-calendar-days mr-1 md:mr-2"></i>
           <p>
             <%= I18n.l(@event.date, format: "%Y/%m/%d(%a)") %>
           </p>
         </div>
-        <div class="flex items-center">
-          <i class="fa-solid fa-location-dot mr-1"></i>
+        <div class="flex items-center justify-center">
+          <i class="fa-solid fa-location-dot mr-1 md:mr-2"></i>
           <p>
             <%= t("activerecord.attributes.event.place_prefecture.#{@event.place_prefecture}") %> <%= @event.place %>
           </p>
         </div>
         <% if @event.remark.present? %>
-          <div class="flex items-start mt-3">
+          <div class="flex items-start mt-3 lg:justify-center">
             <%= @event.remark %>
           </div>
         <% end %>
@@ -46,11 +46,11 @@
         <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">収録情報</h2>
       </div>
       <% if @disc_contents.present? %>
-        <div class="grid grid-cols-1 md:grid-cols-2">
+        <div class="grid grid-cols-1 lg:grid-cols-2">
           <% @disc_contents.each do |content| %>
             <div class="mx-3">
-              <div class="h-32 md:h-40 w-full my-2 flex justify-center">
-                <%= link_to disc_path(content.disc_version.disc), class: "w-32 h-full md:w-40" do %>
+              <div class="h-32 w-full my-2 flex justify-center">
+                <%= link_to disc_path(content.disc_version.disc), class: "w-32 h-full" do %>
                   <turbo-frame id="jacket_<%= content.disc_version.id %>" src="/version_jacket/<%= content.disc_version.id %>" loading="lazy">
                     <div class="skeleton w-full h-full flex items-center justify-center">
                       <span class="loading loading-spinner loading-xs"></span>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,34 +5,8 @@
       <% if @event.is_canceled? %>
         <br>（開催見合わせ）
       <% end %>
-  </div>
-
-  <div class="mb-5">
-    <div class="divider mb-5">
-      <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">概要</h2>
-    </div>
     </h1>
-    <div class="text-sm md:text-base">
-      <div class="flex items-center">
-        <i class="fa-solid fa-calendar-days mr-1"></i>
-        <p>
-          <%= I18n.l(@event.date, format: "%Y/%m/%d(%a)") %>
-        </p>
-      </div>
-      <div class="flex items-center">
-        <i class="fa-solid fa-location-dot mr-1"></i>
-        <p>
-          <%= t("activerecord.attributes.event.place_prefecture.#{@event.place_prefecture}") %> <%= @event.place %>
-        </p>
-      </div>
-      <% if @event.remark.present? %>
-        <div class="flex items-start mt-3">
-          <%= @event.remark %>
-        </div>
-      <% end %>
-    </div>
   </div>
-
 
   <% if @event.tour_id %>
     <div class="card-actions justify-end mb-5">
@@ -40,36 +14,64 @@
     </div>
   <% end %>
 
-  <div class="mb-8">
-    <div class="divider mb-5">
-      <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">収録情報</h2>
-    </div>
-    <% if @disc_contents.present? %>
-      <div class="grid grid-cols-1 md:grid-cols-2">
-        <% @disc_contents.each do |content| %>
-          <div class="mx-3">
-            <div class="h-32 md:h-40 w-full my-2 flex justify-center">
-              <%= link_to disc_path(content.disc_version.disc), class: "w-32 h-full md:w-40" do %>
-                <turbo-frame id="jacket_<%= content.disc_version.id %>" src="/version_jacket/<%= content.disc_version.id %>" loading="lazy">
-                  <div class="skeleton w-full h-full flex items-center justify-center">
-                    <span class="loading loading-spinner loading-xs"></span>
-                  </div>
-                </turbo_frame>
-              <% end %>
-            </div>
-            <p class="text-xs text-center mb-2">
-              <%= link_to disc_path(content.disc_version.disc_id), class: "link link-primary" do %>
-                <%= content.disc_version.disc.title %><br>
-                （<%= t("activerecord.attributes.disc_version.#{content.disc_version.version}") %>）<br>
-              <% end %>
-            </p>
+  <div>
+    <div class="mb-5">
+      <div class="divider mb-5">
+        <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">概要</h2>
+      </div>
+      </h1>
+      <div class="text-sm md:text-base">
+        <div class="flex items-center">
+          <i class="fa-solid fa-calendar-days mr-1"></i>
+          <p>
+            <%= I18n.l(@event.date, format: "%Y/%m/%d(%a)") %>
+          </p>
+        </div>
+        <div class="flex items-center">
+          <i class="fa-solid fa-location-dot mr-1"></i>
+          <p>
+            <%= t("activerecord.attributes.event.place_prefecture.#{@event.place_prefecture}") %> <%= @event.place %>
+          </p>
+        </div>
+        <% if @event.remark.present? %>
+          <div class="flex items-start mt-3">
+            <%= @event.remark %>
           </div>
         <% end %>
       </div>
-      <p class="text-center">に収録されています！</p>
-    <% else %>
-      <p class="text-center">😑この日の映像は発売されてないヨ😑</p>
-    <% end %>
+    </div>
+
+    <div class="mb-8">
+      <div class="divider mb-5">
+        <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">収録情報</h2>
+      </div>
+      <% if @disc_contents.present? %>
+        <div class="grid grid-cols-1 md:grid-cols-2">
+          <% @disc_contents.each do |content| %>
+            <div class="mx-3">
+              <div class="h-32 md:h-40 w-full my-2 flex justify-center">
+                <%= link_to disc_path(content.disc_version.disc), class: "w-32 h-full md:w-40" do %>
+                  <turbo-frame id="jacket_<%= content.disc_version.id %>" src="/version_jacket/<%= content.disc_version.id %>" loading="lazy">
+                    <div class="skeleton w-full h-full flex items-center justify-center">
+                      <span class="loading loading-spinner loading-xs"></span>
+                    </div>
+                  </turbo_frame>
+                <% end %>
+              </div>
+              <p class="text-xs text-center mb-2">
+                <%= link_to disc_path(content.disc_version.disc_id), class: "link link-primary" do %>
+                  <%= content.disc_version.disc.title %><br>
+                  （<%= t("activerecord.attributes.disc_version.#{content.disc_version.version}") %>）<br>
+                <% end %>
+              </p>
+            </div>
+          <% end %>
+        </div>
+        <p class="text-center">に収録されています！</p>
+      <% else %>
+        <p class="text-center">😑この日の映像は発売されてないヨ😑</p>
+      <% end %>
+    </div>
   </div>
 
   <div class="divider mb-8">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,16 +1,3 @@
-<% 
-=begin
-%>
-<div class="relative">
-  <% if @event.visual_image.attached? %>
-    <%= image_tag @event.visual_image.variant(resize_to_fill: [600, 200]), class: "w-full contrast-50 blur-sm" %>
-    <h1 class="text-slate-50 truncate absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 font-semibold text-3xl md:text-4xl lg:text-5xl">イベント詳細</h1>
-  <% end %>
-</div>
-<%
-=end
-%>
-
 <div class="m-5">
   <div class="mb-8 leading-8">
     <h1 class="text-center text-xl md:text-2xl font-semibold mb-2">

--- a/app/views/links/_links.html.erb
+++ b/app/views/links/_links.html.erb
@@ -4,12 +4,7 @@
   </h1>
 </div>
 
-<% if link_contents.present? %>
-  <% link_contents.each do |link| %>
-    <%= render partial: "links/link", locals: { link: link.link.url_link, platform: link.link.platform } %>
-  <% end %>
-<% else %>
-  <p class="text-center">
-    SNS上の動画は見つかりませんでした🤥
-  </p>
-<% end %>
+<div>
+  <%= render partial: "links/youtubes", locals: { youtubes: youtubes } %>
+  <%= render partial: "links/tiktoks", locals: { tiktoks: tiktoks } %>
+</div>

--- a/app/views/links/_tiktok.html.erb
+++ b/app/views/links/_tiktok.html.erb
@@ -1,0 +1,9 @@
+<% if url.include?('https://www.tiktok.com') %>
+  <blockquote class="tiktok-embed"
+  cite="https://www.tiktok.com/@ppppeople1/video/<%= find_tiktok_id(url) %>"
+  data-video-id="<%= find_tiktok_id(url) %>"
+  style="max-width: 320px; ">
+    <section>
+    </section>
+  </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>
+<% end %>

--- a/app/views/links/_tiktoks.html.erb
+++ b/app/views/links/_tiktoks.html.erb
@@ -1,0 +1,11 @@
+<h3 class="">【TikTok】</h3>
+
+<% if tiktoks.present? %>
+  <div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-3 lg:gap-5 mt-5">
+    <% tiktoks.each do |tiktok| %>
+      <%= render partial: "links/tiktok", locals: { tiktok: tiktok, url: tiktok.url_link } %>
+    <% end %>
+  </div>
+<% else %>
+  <p>TikTok上で動画は見つかりませんでした🙅‍♂️</p>
+<% end %>

--- a/app/views/links/_youtube.html.erb
+++ b/app/views/links/_youtube.html.erb
@@ -1,0 +1,16 @@
+<div>
+  <% if youtube.url_link.include?('https://youtu.be/') || youtube.url_link.include?('https://www.youtube.com/') %>
+    <iframe
+      src="https://www.youtube.com/embed/<%= find_youtube_url(youtube.url_link) %>"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      referrerpolicy="strict-origin-when-cross-origin"
+      allowfullscreen
+      class="w-full aspect-video mb-5">
+    </iframe>
+  <% end %>
+    <% if youtube.YouTubeMusic? %>
+    <p class="mb-5 text-left text-xs">（上記動画はご利用いただけない場合がございます）</p>
+  <% end %>
+</div>

--- a/app/views/links/_youtubes.html.erb
+++ b/app/views/links/_youtubes.html.erb
@@ -1,0 +1,11 @@
+<h3>【YouTube】</h3>
+
+<% if youtubes.present? %>
+  <div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-3 lg:gap-5 mt-5">
+    <% youtubes.each do |youtube| %>
+      <%= render partial: "links/youtube", locals: { youtube: youtube } %>
+    <% end %>
+  </div>
+<% else %>
+  <p>YouTube上で動画は見つかりませんでした🙅‍♂️</p>
+<% end %>

--- a/app/views/setlistitem_informations/_setlistitem_information.html.erb
+++ b/app/views/setlistitem_informations/_setlistitem_information.html.erb
@@ -11,7 +11,7 @@
       <h2 class="card-title text-base md:text-lg"><%= setlistitem_info.body %></h2>
       <div>
         <% if user_signed_in? %>
-          <%= turbo_frame_tag "like_on_setlistitem_info_#{setlistitem_info}" do %>
+          <%= turbo_frame_tag "like_on_setlistitem_info_#{setlistitem_info.id}" do %>
             <%= render partial: "setlistitems/info_fav_btn", locals: {setlistitem_info: setlistitem_info} %>
           <% end %>
         <% end %>

--- a/app/views/setlistitem_informations/_setlistitem_information.html.erb
+++ b/app/views/setlistitem_informations/_setlistitem_information.html.erb
@@ -11,7 +11,9 @@
       <h2 class="card-title text-base md:text-lg"><%= setlistitem_info.body %></h2>
       <div>
         <% if user_signed_in? %>
-          <%= render partial: "setlistitems/info_fav_btn", locals: {setlistitem_information: setlistitem_info} %>
+          <%= turbo_frame_tag "like_on_setlistitem_info_#{setlistitem_info}" do %>
+            <%= render partial: "setlistitems/info_fav_btn", locals: {setlistitem_info: setlistitem_info} %>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/setlistitem_informations/_setlistitem_information.html.erb
+++ b/app/views/setlistitem_informations/_setlistitem_information.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag setlistitem_info do %>
-  <div class="card bg-base-100 w-full shadow-xl mb-3">
+  <div class="card bg-base-100 w-full h-full shadow-xl mb-3">
     <div class="card-body">
       <div class="avatar flex items-center">
         <div class="w-4 md:w-6 rounded-full mr-1 md:mr-2">

--- a/app/views/setlistitem_informations/_setlistitem_informations.html.erb
+++ b/app/views/setlistitem_informations/_setlistitem_informations.html.erb
@@ -1,7 +1,5 @@
 <%= turbo_frame_tag item do %>
   <% infos.each do |info| %>
-    <% if info.setlistitem_id == item.id %>
-      <%= render partial: 'setlistitem_informations/setlistitem_information', locals: {setlistitem_info: info} %>
-    <% end %>
+    <%= render partial: 'setlistitem_informations/setlistitem_information', locals: {setlistitem_info: info} %>
   <% end %>
 <% end %>

--- a/app/views/setlistitem_informations/_setlistitem_informations.html.erb
+++ b/app/views/setlistitem_informations/_setlistitem_informations.html.erb
@@ -1,7 +1,6 @@
-<%= turbo_frame_tag item do %>
-  <div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-3">
-    <% infos.each do |info| %>
-      <%= render partial: 'setlistitem_informations/setlistitem_information', locals: {setlistitem_info: info} %>
-    <% end %>
-  </div>
-<% end %>
+<div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-3">
+  <% infos.each do |info| %>
+    <%= render partial: 'setlistitem_informations/setlistitem_information', locals: {setlistitem_info: info} %>
+  <% end %>
+</div>
+

--- a/app/views/setlistitem_informations/_setlistitem_informations.html.erb
+++ b/app/views/setlistitem_informations/_setlistitem_informations.html.erb
@@ -1,5 +1,7 @@
 <%= turbo_frame_tag item do %>
-  <% infos.each do |info| %>
-    <%= render partial: 'setlistitem_informations/setlistitem_information', locals: {setlistitem_info: info} %>
-  <% end %>
+  <div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-3">
+    <% infos.each do |info| %>
+      <%= render partial: 'setlistitem_informations/setlistitem_information', locals: {setlistitem_info: info} %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/setlistitem_informations/create.turbo_stream.erb
+++ b/app/views/setlistitem_informations/create.turbo_stream.erb
@@ -2,8 +2,8 @@
   <%= render partial: "form", locals: {item: @item} %>
 <% end %>
 
-<%= turbo_stream.prepend @item do %>
-  <%= render partial: "setlistitem_informations/setlistitem_information", locals: {setlistitem_info: @info} %>
+<%= turbo_stream.update "setlistitem_#{@item.id}_infos" do %>
+  <%= render partial: "setlistitem_informations/setlistitem_informations", locals: {infos: @infos, item: @item} %>
 <% end %>
 
 <%= turbo_stream.replace "flash_message" do %>

--- a/app/views/setlistitem_informations/like.turbo_stream.erb
+++ b/app/views/setlistitem_informations/like.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.update "like_on_setlistitem_info_#{setlistitem_info.id}" do %>
+  <%= render partial: "setlistitems/info_fav_btn", locals: {setlistitem_info: setlistitem_info} %>
+  <% p  %>
+<% end %>

--- a/app/views/setlistitem_informations/unlike.turbo_stream.erb
+++ b/app/views/setlistitem_informations/unlike.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.update "like_on_setlistitem_info_#{setlistitem_info.id}" do %>
+  <%= render partial: "setlistitems/info_fav_btn", locals: {setlistitem_info: setlistitem_info} %>
+  <% p "いえいいえい" %>
+<% end %>

--- a/app/views/setlistitems/_info_fav_btn.html.erb
+++ b/app/views/setlistitems/_info_fav_btn.html.erb
@@ -4,12 +4,12 @@
       <%= link_to setlistitem_information_likes_on_setlistitem_informations_path(setlistitem_information), data: { "turbo-method": :delete } do %>
         <i class="fa-solid fa-heart"></i>
       <% end %>
-      <%= setlistitem_information.likes_on_setlistitem_informations.count %> いいね
+      <%= setlistitem_information.likes_on_setlistitem_informations.length %> いいね
     <% else %>
       <%= link_to setlistitem_information_likes_on_setlistitem_informations_path(setlistitem_information), data: { "turbo-method": :post } do %>
         <i class="fa-regular fa-heart"></i>
       <% end %>
-      <%= setlistitem_information.likes_on_setlistitem_informations.count %> いいね
+      <%= setlistitem_information.likes_on_setlistitem_informations.length %> いいね
     <% end %>
   <% end %>
 </div>

--- a/app/views/setlistitems/_info_fav_btn.html.erb
+++ b/app/views/setlistitems/_info_fav_btn.html.erb
@@ -1,15 +1,13 @@
 <div class="text-sm md:text-base">
-  <%= turbo_frame_tag setlistitem_information do %>
-    <% if setlistitem_information.liked_by?(current_user) %>
-      <%= link_to setlistitem_information_likes_on_setlistitem_informations_path(setlistitem_information), data: { "turbo-method": :delete } do %>
-        <i class="fa-solid fa-heart"></i>
-      <% end %>
-      <%= setlistitem_information.likes_on_setlistitem_informations.length %> いいね
-    <% else %>
-      <%= link_to setlistitem_information_likes_on_setlistitem_informations_path(setlistitem_information), data: { "turbo-method": :post } do %>
-        <i class="fa-regular fa-heart"></i>
-      <% end %>
-      <%= setlistitem_information.likes_on_setlistitem_informations.length %> いいね
+  <% if setlistitem_info.liked_by?(current_user) %>
+    <%= link_to setlistitem_information_likes_on_setlistitem_informations_path(setlistitem_info), data: { "turbo-method": :delete } do %>
+      <i class="fa-solid fa-heart"></i>
     <% end %>
+    <%= setlistitem_info.likes_on_setlistitem_informations.length %> いいね
+  <% else %>
+    <%= link_to setlistitem_information_likes_on_setlistitem_informations_path(setlistitem_info), data: { "turbo-method": :post } do %>
+      <i class="fa-regular fa-heart"></i>
+    <% end %>
+    <%= setlistitem_info.likes_on_setlistitem_informations.length %> いいね
   <% end %>
 </div>

--- a/app/views/shared/_after_login_footer.html.erb
+++ b/app/views/shared/_after_login_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="btm-nav">
+<div class="btm-nav z-20">
   <%= link_to events_path, class: (current_page?(controller: 'events') ? 'active' : '') do %>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="btm-nav">
+<div class="btm-nav z-20">
   <%= link_to events_path do %>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "flash_message" do %>
-  <div class="w-9/10 fixed top-20 left-0 right-0 truncate z-10 text-sm md:text-base text-left">
+  <div class="w-9/10 fixed top-20 left-0 right-0 truncate z-20 text-sm md:text-base text-left">
     <% flash.each do |message_type, message| %>
       <div
         role="alert"

--- a/app/views/song_informations/_form.html.erb
+++ b/app/views/song_informations/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="card shadow-2xl mb-5">
       <div class="card-body">
         <div class="flex">
-          <h2 class="card-title text-base	md:text-xl">情報の提供にご協力お願いします！🙇</h2>
+          <h2 class="card-title text-base	md:text-xl">自由に書き込んでください😉</h2>
           <%= render partial: "songs/modals/song_info_modal" %>
         </div>
         <%= render 'shared/error_messages', model: f.object %>

--- a/app/views/song_informations/_song_information.html.erb
+++ b/app/views/song_informations/_song_information.html.erb
@@ -1,19 +1,17 @@
-<%= turbo_frame_tag song_information do %>
-  <div class="card bg-base-100 w-full shadow-xl mb-3">
-    <div class="card-body">
-      <div class="avatar flex items-center">
-        <div class="w-4 md:w-6 rounded-full mr-1 md:mr-2">
-          <img src="<%= song_information.user.image %>" />
-        </div>
-        <h3 class="text-xs	md:text-base mr-1"><%= song_information.user.name %></h3>
-        <p class="font-light text-slate-300 text-xs	md:text-base">（<%= time_ago_in_words(song_information.created_at) %>前）</p>
+<div class="card bg-base-100 w-full shadow-xl mb-3">
+  <div class="card-body">
+    <div class="avatar flex items-center">
+      <div class="w-4 md:w-6 rounded-full mr-1 md:mr-2">
+        <img src="<%= song_information.user.image %>" />
       </div>
-      <h2 class="card-title text-base md:text-lg"><%= song_information.body %></h2>
-      <div>
-        <% if user_signed_in? %>
-          <%= render partial: "songs/info_fav_btn", locals: {song_information: song_information} %>
-        <% end %>
-      </div>
+      <h3 class="text-xs	md:text-base mr-1"><%= song_information.user.name.truncate(16) %></h3>
+      <p class="font-light text-slate-300 text-xs	md:text-base">（<%= time_ago_in_words(song_information.created_at) %>前）</p>
+    </div>
+    <h2 class="card-title text-base md:text-lg"><%= song_information.body %></h2>
+    <div>
+      <% if user_signed_in? %>
+        <%= render partial: "songs/info_fav_btn", locals: {song_information: song_information} %>
+      <% end %>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/song_informations/_song_informations.html.erb
+++ b/app/views/song_informations/_song_informations.html.erb
@@ -1,5 +1,5 @@
-<div>
-  <% @song_informations.each do |info| %>
+<div class="md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-5">
+  <% song_informations.each do |info| %>
     <%= render partial: "song_informations/song_information", locals: {song_information: info} %>
   <% end %>
 </div>

--- a/app/views/song_informations/create.turbo_stream.erb
+++ b/app/views/song_informations/create.turbo_stream.erb
@@ -2,8 +2,8 @@
   <%= render partial: "form", locals: { song: @song, info: @new_song_information } %>
 <% end %>
 
-<%= turbo_stream.prepend "song_informations" do %>
-  <%= render partial: "song_informations/song_information", locals: { song_information: @info } %>
+<%= turbo_stream.update "song_informations" do %>
+  <%= render partial: "song_informations/song_informations", locals: { song_informations: @song_informations } %>
 <% end %>
 
 <%= turbo_stream.replace "flash_message" do %>

--- a/app/views/songs/_info_fav_btn.html.erb
+++ b/app/views/songs/_info_fav_btn.html.erb
@@ -7,7 +7,7 @@
   <% else %>
     <%= link_to song_information_likes_on_song_informations_path(song_information), data: { "turbo-method": :post }, remote: true do %>
       <i class="fa-regular fa-heart"></i>
-      <%= song_information.likes_on_song_informations.count %> いいね
+      <%= song_information.likes_on_song_informations.length %> いいね
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -3,17 +3,28 @@
     <%= title @song.name %>
   </h1>
 
-  <div class="divider mb-3 md:mb-8">
-    <h1 class="font-bold sm:text-xl md:text-2xl">
+  <div class="divider mb-5 md:mb-8">
+    <h2 class="font-bold sm:text-xl md:text-2xl">
       演奏記録
-    </h1>
+    </h2>
   </div>
 
-  <div class="mb-3 md:mb-8">
+  <div class="mb-5 md:mb-8">
     <% if @events.present? %>
-      <div class="mb-2 md:mb-4 text-center md:flex md:justify-center md:gap-8 lg:gap-16">
+      <p class="text-center md:text-lg mb-3">👏今まで計<%= @events.length %>回演奏されました👏</p>
+      <div class="mb-2 md:mb-4 text-center md:grid md:grid-cols-2 md:gap-2 lg:mx-36">
         <div class="leading-8">
-          <p>【ライブ初演奏🎉】</p>
+          <h3 class="md:text-xl">【ライブ初演奏🎉】</h3>
+          <div class="my-5 flex items-center justify-center w-full h-60 md:h-80">
+            <%= link_to event_path(@events.first), class: "w-60 md:w-80 h-full" do %>
+              <turbo-frame id="visual_image_<%= @events.first.id %>" src="/visual_images/<%= @events.first.id %>" loading="lazy">
+                <div class="skeleton w-full h-full flex items-center justify-center">
+                  <span class="loading loading-spinner loading-xs mr-1"></span>
+                  <p class="text-center">画像読み込み中...</p>
+                </div>
+              </turbo_frame>
+            <% end %>
+          </div>
           <p>
             <%= I18n.l(@events.first.date, format: "%Y/%m/%d（%a）") %><br>
             <%= link_to event_path(@events.first.id), class: "link link-primary" do %>
@@ -25,7 +36,17 @@
           </p>
         </div>
         <div class="leading-8">
-          <p>【直近での演奏👻】</p>
+          <h3 class="md:text-xl">【直近での演奏👻】</h3>
+          <div class="my-5 flex items-center justify-center w-full h-60 md:h-80">
+            <%= link_to event_path(@events.last), class: "w-60 md:w-80 h-full" do %>
+              <turbo-frame id="visual_image_<%= @events.last.id %>" src="/visual_images/<%= @events.last.id %>" loading="lazy">
+                <div class="skeleton w-full h-full flex items-center justify-center">
+                  <span class="loading loading-spinner loading-xs mr-1"></span>
+                  <p class="text-center">画像読み込み中...</p>
+                </div>
+              </turbo_frame>
+            <% end %>
+          </div>
           <p>
             <%= I18n.l(@events.last.date, format: "%Y/%m/%d（%a）") %><br>
             <%= link_to event_path(@events.last.id), class: "link link-primary" do %>
@@ -37,7 +58,6 @@
           </p>
         </div>
       </div>
-      <p class="text-center">👏今まで計<%= @events.length %>回演奏されました👏</p>
     <% else %>
       <p class="text-center">ライブ演奏の情報は現時点ではありません🤥</p>
     <% end %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -71,7 +71,7 @@
 
   <div class="mb-5 mx-3 leading-8">
     <div>
-      <p class="text-center">【音源】</p>
+      <p class="text-center lg:text-left my-3">【音源】</p>
       <% if @song_disc_items.present? %>
         <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6">
           <% @song_disc_items.each do |disc_item| %>
@@ -95,34 +95,43 @@
           <% end %>
         </div>
       <% else %>
-        <p class="text-left">収録情報はありません🤥</p>
+        <p class="text-center lg:text-left">収録情報はありません🤥</p>
       <% end %>
     </div>
     <div>
-      <p class="text-left">【映像】</p>
+      <p class="text-center lg:text-left my-3">【映像】</p>
       <% if @movie_disc_items.present? %>
-        <ul class="list-disc ml-5">
+        <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6">
           <% @movie_disc_items.each do |disc_item| %>
-            <li class="text-left">
-              <%= link_to disc_path(disc_item.disc_content.disc_version.disc_id) do %>
-                <p class="link link-primary">
-                <%= disc_item.show_disc_title %>
-                （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）
-                </p>
-              <% end %>
-              <% if disc_item.disc_content.event.present? %>
-                <%= disc_item.show_event_title %>
-                ＠<%= disc_item.show_event_place %>公演
-              <% elsif disc_item.title.present? %>
-                <%= disc_item.show_disc_title %>
-                （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）
-                <%= disc_item.title %>
-              <% end %>
-            </li>
+            <div class="mx-3">
+              <div class="h-24 md:h-28 md:h-32 w-full my-2 flex justify-center">
+                <%= link_to disc_path(disc_item.disc_content.disc_version.disc), class: "w-24 h-full md:w-28 md:w-32" do %>
+                  <turbo-frame id="jacket_<%= disc_item.disc_content.disc_version.id %>" src="/version_jacket/<%= disc_item.disc_content.disc_version.id %>" loading="lazy">
+                    <div class="skeleton w-full h-full flex items-center justify-center">
+                      <span class="loading loading-spinner loading-xs"></span>
+                    </div>
+                  </turbo_frame>
+                <% end %>
+              </div>
+              <p class="text-xs text-center mb-2">
+                <%= link_to disc_path(disc_item.disc_content.disc_version.disc_id), class: "link link-primary" do %>
+                  <%= disc_item.show_disc_title %><br>
+                  （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）<br>
+                <% end %>
+                <% if disc_item.disc_content.event.present? %>
+                  <%= disc_item.show_event_title %><br>
+                  ＠<%= disc_item.show_event_place %>公演
+                <% elsif disc_item.title.present? %>
+                  <%= disc_item.show_disc_title %><br>
+                  （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）<br>
+                  <%= disc_item.title %>
+                <% end %>
+              </p>
+            </div>
           <% end %>
-        </ul>
+        </div>
       <% else %>
-        <p class="text-left">収録情報はありません🤥</p>
+        <p class="text-center lg:text-left">収録情報はありません🤥</p>
       <% end %>
     </div>
   </div>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -142,6 +142,6 @@
   <div class="divider">楽曲情報</div>
   <%= render partial: "song_informations/form", locals: { info: @new_song_information, song: @song } %>
   <%= turbo_frame_tag 'song_informations' do %>
-    <%= render partial: "song_informations/song_informations" %>
+    <%= render partial: "song_informations/song_informations", locals: { song_informations: @song_informations } %>
   <% end %>
 </div>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -61,6 +61,7 @@
     <% else %>
       <p class="text-center">ライブ演奏の情報は現時点ではありません🤥</p>
     <% end %>
+    <p class="text-center mt-1">※登録されたセットリストをもとに算出しています。<br>セットリストの登録は、<br><%= link_to "イベントページ", events_path, class: "link link-primary" %>からお願いします！</p>
   </div>
 
   <div class="divider mb-3">

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -70,46 +70,61 @@
   </div>
 
   <div class="mb-5 mx-3 leading-8">
-    <p class="text-left">【音源】</p>
-    <% if @song_disc_items.present? %>
-      <ul class="list-disc ml-5">
-        <% @song_disc_items.each do |disc_item| %>
-          <li class="text-left">
-            <%= link_to disc_path(disc_item.disc_content.disc_version.disc_id), class: "link link-primary" do %>
-              <%= disc_item.show_disc_title %>
-              （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="text-left">収録情報はありません🤥</p>
-    <% end %>
-    <p class="text-left">【映像】</p>
-    <% if @movie_disc_items.present? %>
-      <ul class="list-disc ml-5">
-        <% @movie_disc_items.each do |disc_item| %>
-          <li class="text-left">
-            <%= link_to disc_path(disc_item.disc_content.disc_version.disc_id) do %>
-              <p class="link link-primary">
-              <%= disc_item.show_disc_title %>
-              （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）
+    <div>
+      <p class="text-center">【音源】</p>
+      <% if @song_disc_items.present? %>
+        <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6">
+          <% @song_disc_items.each do |disc_item| %>
+            <div class="mx-3">
+              <div class="h-24 md:h-28 md:h-32 w-full my-2 flex justify-center">
+                <%= link_to disc_path(disc_item.disc_content.disc_version.disc), class: "w-24 h-full md:w-28 md:w-32" do %>
+                  <turbo-frame id="jacket_<%= disc_item.disc_content.disc_version.id %>" src="/version_jacket/<%= disc_item.disc_content.disc_version.id %>" loading="lazy">
+                    <div class="skeleton w-full h-full flex items-center justify-center">
+                      <span class="loading loading-spinner loading-xs"></span>
+                    </div>
+                  </turbo_frame>
+                <% end %>
+              </div>
+              <p class="text-xs text-center mb-2">
+                <%= link_to disc_path(disc_item.disc_content.disc_version.disc_id), class: "link link-primary" do %>
+                  <%= disc_item.show_disc_title %><br>
+                  （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）
+                <% end %>
               </p>
-            <% end %>
-            <% if disc_item.disc_content.event.present? %>
-              <%= disc_item.show_event_title %>
-              ＠<%= disc_item.show_event_place %>公演
-            <% elsif disc_item.title.present? %>
-              <%= disc_item.show_disc_title %>
-              （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）
-              <%= disc_item.title %>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="text-left">収録情報はありません🤥</p>
-    <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="text-left">収録情報はありません🤥</p>
+      <% end %>
+    </div>
+    <div>
+      <p class="text-left">【映像】</p>
+      <% if @movie_disc_items.present? %>
+        <ul class="list-disc ml-5">
+          <% @movie_disc_items.each do |disc_item| %>
+            <li class="text-left">
+              <%= link_to disc_path(disc_item.disc_content.disc_version.disc_id) do %>
+                <p class="link link-primary">
+                <%= disc_item.show_disc_title %>
+                （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）
+                </p>
+              <% end %>
+              <% if disc_item.disc_content.event.present? %>
+                <%= disc_item.show_event_title %>
+                ＠<%= disc_item.show_event_place %>公演
+              <% elsif disc_item.title.present? %>
+                <%= disc_item.show_disc_title %>
+                （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）
+                <%= disc_item.title %>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-left">収録情報はありません🤥</p>
+      <% end %>
+    </div>
   </div>
 
   <%= render partial: "links/links", locals: { link_contents: @link_contents } %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -124,7 +124,7 @@
                 <% elsif disc_item.title.present? %>
                   <%= disc_item.show_disc_title %><br>
                   （<%= t("activerecord.attributes.disc_version.#{disc_item.show_disc_version}") %>）<br>
-                  <%= disc_item.title %>
+                  <%= disc_item.title.truncate(20) %>
                 <% end %>
               </p>
             </div>
@@ -136,7 +136,7 @@
     </div>
   </div>
 
-  <%= render partial: "links/links", locals: { link_contents: @link_contents } %>
+  <%= render partial: "links/links", locals: { youtubes: @youtube_contents, tiktoks: @tiktok_contents } %>
 
   <div class="divider">楽曲情報</div>
   <%= render partial: "song_informations/form", locals: { info: @new_song_information, song: @song } %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -1,39 +1,41 @@
 <div class="m-5">
-  <h1 class="text-center font-extrabold	sm:text-lg md:text-2xl mb-5">
+  <h1 class="text-center font-extrabold	text-2xl md:text-3xl mb-5 md:mb-10">
     <%= title @song.name %>
   </h1>
 
-  <div class="divider mb-3">
-    <h1 class="font-bold sm:text-lg md:text-xl">
+  <div class="divider mb-3 md:mb-8">
+    <h1 class="font-bold sm:text-xl md:text-2xl">
       演奏記録
     </h1>
   </div>
 
-  <div class="mb-5 leading-8">
+  <div class="mb-3 md:mb-8">
     <% if @events.present? %>
-      <div class="mb-2">
-        <p>【ライブ初演奏🎉】</p>
-        <p>
-          <%= I18n.l(@events.first.date, format: "%Y/%m/%d（%a）") %><br>
-          <%= link_to event_path(@events.first.id), class: "link link-primary" do %>
-            <p>
-              <%= @events.first.name %><br>
-              @<%= @events.first.place %>（<%= @events.first.place_prefecture_i18n %>）
-            </p>
-          <% end %>
-        </p>
-      </div>
-      <div class="mb-2">
-        <p>【直近での演奏👻】</p>
-        <p>
-          <%= I18n.l(@events.last.date, format: "%Y/%m/%d（%a）") %><br>
-          <%= link_to event_path(@events.last.id), class: "link link-primary" do %>
-            <p>
-              <%= @events.last.name %><br>
-              @<%= @events.last.place %>（<%= @events.last.place_prefecture_i18n %>）
-            </p>
-          <% end %>
-        </p>
+      <div class="mb-2 md:mb-4 text-center md:flex md:justify-center md:gap-8 lg:gap-16">
+        <div class="leading-8">
+          <p>【ライブ初演奏🎉】</p>
+          <p>
+            <%= I18n.l(@events.first.date, format: "%Y/%m/%d（%a）") %><br>
+            <%= link_to event_path(@events.first.id), class: "link link-primary" do %>
+              <p>
+                <%= @events.first.name %><br>
+                @<%= @events.first.place %>（<%= @events.first.place_prefecture_i18n %>）
+              </p>
+            <% end %>
+          </p>
+        </div>
+        <div class="leading-8">
+          <p>【直近での演奏👻】</p>
+          <p>
+            <%= I18n.l(@events.last.date, format: "%Y/%m/%d（%a）") %><br>
+            <%= link_to event_path(@events.last.id), class: "link link-primary" do %>
+              <p>
+                <%= @events.last.name %><br>
+                @<%= @events.last.place %>（<%= @events.last.place_prefecture_i18n %>）
+              </p>
+            <% end %>
+          </p>
+        </div>
       </div>
       <p class="text-center">👏今まで計<%= @events.length %>回演奏されました👏</p>
     <% else %>


### PR DESCRIPTION
## 概要
楽曲・イベント詳細ページのレスポンシブ対応実施

## 加えた変更
* 各詳細ページのレスポンシブ対応
  * 楽曲詳細ページ
    [![Image from Gyazo](https://i.gyazo.com/aff1b3ebca9e31d031d789123f951cee.gif)](https://gyazo.com/aff1b3ebca9e31d031d789123f951cee)
    [![Image from Gyazo](https://i.gyazo.com/3d77d297d3992d555566e5e2f62babf6.gif)](https://gyazo.com/3d77d297d3992d555566e5e2f62babf6)
  * イベント詳細ページ
    [![Image from Gyazo](https://i.gyazo.com/6ce44a633fdf6e387c7c541b9c7fd074.gif)](https://gyazo.com/6ce44a633fdf6e387c7c541b9c7fd074)

## 加えなかった変更
* ディスク詳細ページのレスポンシブ対応
* ヒストリー詳細のレスポンシブ対応

## 影響範囲

## 関連Issue
* close #378 
* close #304 