### PR TITLE
Fix 未ログインでもジャケ写を表示できるように修正

### DIFF
--- a/app/controllers/discs_controller.rb
+++ b/app/controllers/discs_controller.rb
@@ -1,4 +1,6 @@
 class DiscsController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[jacket]
+
   def show
     @disc = Disc.includes(link_contents: :link).find(params[:id])
     @youtube_contents = @disc.links.where(platform: "YouTube").or(@disc.links.where(platform: "YouTubeMusic"))


### PR DESCRIPTION
## 概要
未ログインでもジャケ写を表示できるように修正しました。

## 加えた変更
* 従来：（未ログイン時）
  [![Image from Gyazo](https://i.gyazo.com/daab13e0e31666c714d8ff6faeb93f3b.png)](https://gyazo.com/daab13e0e31666c714d8ff6faeb93f3b)
  ジャケット表示アクション実行前に`authenticate_user!`を介さないようにしました。

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
