### PR TITLE
Fix ヒストリー詳細ページ レスポンシブ対応の実施

### DIFF
--- a/app/controllers/discs/informations_controller.rb
+++ b/app/controllers/discs/informations_controller.rb
@@ -8,6 +8,7 @@ class Discs::InformationsController < ApplicationController
         @new_info = @disc.informations.build
         @infos = Information.eager_load(:user, :likes_on_informations).where(reportable_type: "Disc", reportable_id: @disc.id).order(created_at: :desc)
         @type = "disc"
+        @reportable = @disc
         flash.now[:success] = I18n.t('flash.success.post')
         format.turbo_stream { render 'informations/create' }
       else

--- a/app/controllers/histories/informations_controller.rb
+++ b/app/controllers/histories/informations_controller.rb
@@ -6,6 +6,9 @@ class Histories::InformationsController < ApplicationController
     respond_to do |format|
       if @info.save
         @new_info = @history.informations.build
+        @reportable = @history
+        @type = "history"
+        @infos = @history.informations.order(created_at: :desc)
         flash.now[:success] = I18n.t('flash.success.post')
         format.turbo_stream { render 'informations/create' }
       else

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -27,7 +27,7 @@ class HistoriesController < ApplicationController
     @history = History.find(params[:id])
     @new_info = @history.informations.build
     @form_url = history_informations_path(history_id: @history.id)
-    @infos = Information.includes(:user).where(reportable_type: 'History', reportable_id: @history.id).order(created_at: :desc)
+    @infos = Information.includes(:user, :likes_on_informations).where(reportable_type: 'History', reportable_id: @history.id).order(created_at: :desc)
   end
 
   def new

--- a/app/views/histories/show.html.erb
+++ b/app/views/histories/show.html.erb
@@ -11,40 +11,45 @@
     </div>
   </div>
 
-  <div class="lg:mb-8">
-    <div class="flex items-center justify-center w-full h-60 md:h-80">
-      <div class="w-60 md:w-80 h-full">
-        <turbo-frame id="history_image" src="/histories/images/<%= @history.id %>" loading="lazy">
-          <div class="skeleton w-full h-full flex items-center justify-center">
-            <span class="loading loading-spinner loading-xs mr-1"></span>
-            <p class="text-center">画像読み込み中...</p>
-          </div>
-        </turbo-frame>
+  <div class="md:grid md:grid-cols-5 md:gap-5">
+    <div class="md:col-span-2">
+      <div class="flex items-center justify-center w-full h-60 mb-2">
+        <div class="w-60 h-full">
+          <turbo-frame id="history_image" src="/histories/images/<%= @history.id %>" loading="lazy">
+            <div class="skeleton w-full h-full flex items-center justify-center">
+              <span class="loading loading-spinner loading-xs mr-1"></span>
+              <p class="text-center">画像読み込み中...</p>
+            </div>
+          </turbo-frame>
+        </div>
       </div>
     </div>
-    <div class="flex justify-end mt-3">
-      <%= render partial: "likes/likes", locals: { history: @history, likes: @history.likes, like_url: history_likes_path(history_id: @history.id) } %>
-      <% if @history.user == current_user %>
-        <%= link_to edit_history_path(@history.id) do %>
-          <i class="fa-solid fa-pen-to-square mr-3"></i>
+    <div class="md:col-span-3">
+      <div class="">
+        <div class="flex items-center mb-2">
+          <i class="mr-2 fa-solid fa-calendar-days"></i>
+          <p class=""><%= I18n.l(@history.date, format: "%Y/%m/%d(%a)") %></p>
+        </div>
+        <div class="md:flex md:items-end">
+          <p class="md:text-2xl mr-2"><%= @history.title %></p>
+        </div>
+      </div>
+      <div class="mt-3">
+        <%= @history.remark.present? ? @history.remark : nil %>
+      </div>
+      <div class="flex justify-end md:justify-start mt-3">
+        <% if @history.user == current_user %>
+          <%= link_to edit_history_path(@history.id) do %>
+            <i class="fa-solid fa-pen-to-square mr-3"></i>
+          <% end %>
+          <%= link_to history_path(@history.id), data: { "turbo-method": :delete, turbo_confirm: "投稿を削除します。よろしいですか？" } do %>
+            <i class="fa-solid fa-trash-can mr-3"></i>
+          <% end %>
         <% end %>
-        <%= link_to history_path(@history.id), data: { "turbo-method": :delete, turbo_confirm: "投稿を削除します。よろしいですか？" } do %>
-          <i class="fa-solid fa-trash-can"></i>
-        <% end %>
-      <% end %>
-    </div>
-    <div class="text-center">
-      <p class="mb-3"><%= I18n.l(@history.date, format: "%Y/%m/%d(%a)") %></p>
-      <p class="md:text-2xl md:mb-5 lg:text-3xl"><%= @history.title %></p>
+        <%= render partial: "likes/likes", locals: { history: @history, likes: @history.likes, like_url: history_likes_path(history_id: @history.id) } %>
+      </div>
     </div>
   </div>
-
-  <% if @history.remark.present? %>
-    <div class="divider mb-3 md:mb-8">
-      <p class="md:text-lg">概要</p>
-    </div>
-    <p class="md:text-lg"><%= @history.remark %></p>
-  <% end %>
 
 
   <div>

--- a/app/views/histories/show.html.erb
+++ b/app/views/histories/show.html.erb
@@ -54,5 +54,8 @@
     <div>
     <%= render partial: "informations/form", locals: { reportable: @history, new_info: @new_info, form_url: @form_url } %>
   </div>
-  <%= render partial: "informations/informations", locals: { infos: @infos } %>
+
+  <%= turbo_frame_tag 'history_infos' do %>
+    <%= render partial: "informations/informations", locals: { infos: @infos } %>
+  <% end %>
 </div>

--- a/app/views/histories/show.html.erb
+++ b/app/views/histories/show.html.erb
@@ -12,25 +12,27 @@
   </div>
 
   <div class="lg:mb-8">
-    <div class="flex justify-center mb-5">
-      <turbo-frame id="history_image" src="/histories/images/<%= @history.id %>" loading="lazy">
-        <div class="my-3 flex">
-          <span class="loading loading-spinner loading-xs mr-1"></span>
-          <p class="text-center">画像読み込み中...</p>
-        </div>
-      </turbo-frame>
-    </div>
-      <div class="flex justify-end mt-3">
-        <%= render partial: "likes/likes", locals: { history: @history, likes: @history.likes, like_url: history_likes_path(history_id: @history.id) } %>
-        <% if @history.user == current_user %>
-          <%= link_to edit_history_path(@history.id) do %>
-            <i class="fa-solid fa-pen-to-square mr-3"></i>
-          <% end %>
-          <%= link_to history_path(@history.id), data: { "turbo-method": :delete, turbo_confirm: "投稿を削除します。よろしいですか？" } do %>
-            <i class="fa-solid fa-trash-can"></i>
-          <% end %>
-        <% end %>
+    <div class="flex items-center justify-center w-full h-60 md:h-80">
+      <div class="w-60 md:w-80 h-full">
+        <turbo-frame id="history_image" src="/histories/images/<%= @history.id %>" loading="lazy">
+          <div class="skeleton w-full h-full flex items-center justify-center">
+            <span class="loading loading-spinner loading-xs mr-1"></span>
+            <p class="text-center">画像読み込み中...</p>
+          </div>
+        </turbo-frame>
       </div>
+    </div>
+    <div class="flex justify-end mt-3">
+      <%= render partial: "likes/likes", locals: { history: @history, likes: @history.likes, like_url: history_likes_path(history_id: @history.id) } %>
+      <% if @history.user == current_user %>
+        <%= link_to edit_history_path(@history.id) do %>
+          <i class="fa-solid fa-pen-to-square mr-3"></i>
+        <% end %>
+        <%= link_to history_path(@history.id), data: { "turbo-method": :delete, turbo_confirm: "投稿を削除します。よろしいですか？" } do %>
+          <i class="fa-solid fa-trash-can"></i>
+        <% end %>
+      <% end %>
+    </div>
     <div class="text-center">
       <p class="mb-3"><%= I18n.l(@history.date, format: "%Y/%m/%d(%a)") %></p>
       <p class="md:text-2xl md:mb-5 lg:text-3xl"><%= @history.title %></p>

--- a/app/views/informations/_form.html.erb
+++ b/app/views/informations/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="card shadow-2xl mb-5">
       <div class="card-body">
         <div class="flex">
-          <h2 class="card-title text-base	md:text-xl">情報の提供にご協力お願いします！🙇</h2>
+          <h2 class="card-title text-base	md:text-xl">自由に書き込んでください👍</h2>
           <%#= render partial: "modal" %>
         </div>
         <%= render 'shared/error_messages', model: f.object %>

--- a/app/views/informations/create.turbo_stream.erb
+++ b/app/views/informations/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.replace "new_info" do %>
-  <%= render partial: "informations/form", locals: { reportable: @disc, new_info: @new_info, form_url: @form_url } %>
+  <%= render partial: "informations/form", locals: { reportable: @reportable, new_info: @new_info, form_url: @form_url } %>
 <% end %>
 
 <%= turbo_stream.update "#{@type}_infos" do %>


### PR DESCRIPTION
## 概要
ヒストリー詳細ページのレスポンシブ対応を行いました。

## 加えた変更
* ヒストリー詳細ページのレスポンシブ対応実施
  [![Image from Gyazo](https://i.gyazo.com/a0a3f475fdc05371aa5d87e12499e60e.gif)](https://gyazo.com/a0a3f475fdc05371aa5d87e12499e60e)

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
