### PR TITLE
Fix メンバー詳細ページ レスポンシブ対応

### DIFF
--- a/app/views/instruments/_instrument.html.erb
+++ b/app/views/instruments/_instrument.html.erb
@@ -8,7 +8,10 @@
         ・<%= gear.name %>
         <div class="my-3 h-32 w-32 md:h-48 md:w-48 lg:h-64 lg:w-64">
           <turbo-frame id="gear_image_<%= gear.id %>" src="/gear/<%= gear.id %>/image" loading="lazy">
-            <div class="skeleton w-full h-full"></div>
+            <div class="skeleton text-xs w-full h-full flex items-center justify-center">
+              <span class="loading loading-spinner loading-xs mr-1"></span>
+              <p class="text-center">画像読み込み中...</p>
+            </div>
           </turbo-frame>
         </div>
         <% if gear.remark.present? %>

--- a/app/views/instruments/_instrument.html.erb
+++ b/app/views/instruments/_instrument.html.erb
@@ -1,0 +1,22 @@
+<div>
+  <li class="text-lg md:text-xl lg:text-2xl md:mb-3">
+    <%= instrument.name %>
+  </li>
+  <div class="ml-5">
+    <% instrument.gears.each do |gear| %>
+      <div class="">
+        ・<%= gear.name %>
+        <div class="my-3 h-32 w-32 md:h-48 md:w-48 lg:h-64 lg:w-64">
+          <turbo-frame id="gear_image_<%= gear.id %>" src="/gear/<%= gear.id %>/image" loading="lazy">
+            <div class="skeleton w-full h-full"></div>
+          </turbo-frame>
+        </div>
+        <% if gear.remark.present? %>
+          <p class="ml-5">
+          （<%= gear.remark %>）
+          </p>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/instruments/_instruments.html.erb
+++ b/app/views/instruments/_instruments.html.erb
@@ -1,0 +1,7 @@
+<ul class="list-disc list-inside">
+  <div class="md:grid md:grid-cols-2 md:gap-3 lg:grid-cols-3 lg:gap-5">
+  <% instruments.each do |instrument| %>
+    <%= render partial: "instruments/instrument", locals: {instrument: instrument} %>
+  <% end %>
+  </div>
+</ul>

--- a/app/views/members/gear_image.html.erb
+++ b/app/views/members/gear_image.html.erb
@@ -1,9 +1,9 @@
 <turbo-frame id="gear_image_<%= @gear.id %>">
   <% if @gear.image.attached? %>
-    <%= image_tag @gear.image.variant(resize_to_fill: [200, 200], format: :webp), class: "w-full" %>
+    <%= image_tag @gear.image.variant(resize_to_fill: [400, 400], format: :webp), class: "w-full" %>
   <% else %>
     <div class="skeleton w-full h-full flex items-center justify-center">
-      <p class="text-sm text-center">画像は<br>ちょい待ち</p>
+      <p class="text-sm text-center">画像は<br>ないよ</p>
     </div>
   <% end %>
 </turbo-frame>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -76,34 +76,7 @@
     <h2 class="font-bold text-lg md:text-2xl lg:text-3xl">担当楽器・使用機材</h2>
   </div>
   <div class="md:mx-5 md:text-lg lg:mx-10 lg:mb-10">
-    <ul class="list-disc list-inside">
-      <div class="md:grid md:grid-cols-2 md:gap-3 lg:grid-cols-3 lg:gap-5">
-      <% @member.instruments.each do |instrument| %>
-        <div>
-          <li class="text-lg md:text-xl lg:text-2xl md:mb-3">
-            <%= instrument.name %>
-          </li>
-          <div class="ml-5">
-            <% instrument.gears.each do |gear| %>
-              <div class="">
-                ・<%= gear.name %>
-                <div class="my-3 h-32 w-32 md:h-48 md:w-48 lg:h-64 lg:w-64">
-                  <turbo-frame id="gear_image_<%= gear.id %>" src="/gear/<%= gear.id %>/image" loading="lazy">
-                    <div class="skeleton w-full h-full"></div>
-                  </turbo-frame>
-                </div>
-                <% if gear.remark.present? %>
-                  <p class="ml-5">
-                  （<%= gear.remark %>）
-                  </p>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-      </div>
-    </ul>
+    <%= render partial: "instruments/instruments", locals: {instruments: @member.instruments} %>
   </div>
 
   <div class="divider mb-5">


### PR DESCRIPTION
## 概要
メンバー詳細ページのレイアウトを微修正しました。

## 加えた変更
* 画像ロード中の表示変更
  [![Image from Gyazo](https://i.gyazo.com/195c702defb5b1235e5e8d2ecaedd18c.gif)](https://gyazo.com/195c702defb5b1235e5e8d2ecaedd18c)

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
