### PR TITLE
Feat セットリストのXシェアボタン表示

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -86,7 +86,7 @@
       <p><%= @event.setlist.user.name.truncate(20) %><p>
     </div>
     <div class="mb-5 flex items-center justify-end">
-      <%= link_to root_path, class: "btn btn-secondary" do %>
+      <%= link_to "https://twitter.com/share?url=#{event_url(@event)}&text=【セトリ情報】%0a#{current_user.name}さんが、「#{@event.name.truncate(50)}」でのPEOPLE 1 セットリストをシェアしました！%0a%0a", target: '_blank', class: "btn btn-secondary" do %>
         <p>セットリストを<i class="fa-brands fa-square-x-twitter fa-lg mx-1"></i>でシェア</p>
       <% end %>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -83,7 +83,12 @@
       <div class="w-6 rounded-full mr-2">
         <img src="<%= @event.setlist.user.image %>" />
       </div>
-      <p><%= @event.setlist.user.name %><p>
+      <p><%= @event.setlist.user.name.truncate(20) %><p>
+    </div>
+    <div class="mb-5 flex items-center justify-end">
+      <%= link_to root_path, class: "btn btn-secondary" do %>
+        <p>セットリストを<i class="fa-brands fa-square-x-twitter fa-lg mx-1"></i>でシェア</p>
+      <% end %>
     </div>
     <%= render partial: 'events/setlistitem', locals: {setlistitems: @setlistitems, infos: @infos} %>
   <% elsif @event.is_canceled? %>


### PR DESCRIPTION
## 概要
セットリストをXでシェアするためのボタンを設置しました。

## 加えた変更
* Xシェアボタンの表示
  [![Image from Gyazo](https://i.gyazo.com/fa3b7dc12504ee055732d6d754ef9de7.gif)](https://gyazo.com/fa3b7dc12504ee055732d6d754ef9de7)

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* #427 
