### PR TITLE
Fix: 本番環境でfontsファイルが読み込まれるように記述を修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
## 概要
本番環境で動的OGPの生成が上手くいかないため、修正しました。

## 加えた変更
* config/environments/production.rbの記述修正
  （参考：https://laced-bugle-850.notion.site/2025-02-06-OGP-1911d78d26d6807db75cf3f27ae28ec4?pvs=4）

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
