### PR TITLE
Fix 読み込むフォントファイルを簡略化

### DIFF
--- a/app/controllers/concerns/ogp_creator.rb
+++ b/app/controllers/concerns/ogp_creator.rb
@@ -1,7 +1,7 @@
 class OgpCreator
   require 'mini_magick'
   BASE_IMAGE_PATH = './app/assets/images/dynamic_ogp_background.jpeg'.freeze
-  FONT = './app/assets/fonts/DotGothic16,M_PLUS_1p/DotGothic16/DotGothic16-Regular.ttf'.freeze
+  FONT = './app/assets/fonts/DotGothic16/DotGothic16-Regular.ttf'.freeze
   GRAVITY = 'NorthWest'.freeze
   ONE_LINE_MAX_LENGTH = 26
   TWO_LINE_FONT_SIZE = 25


### PR DESCRIPTION
## 概要
本番での動的OGP生成時に発生する下記エラーの解消に着手中。
```
unable to read font `./app/assets/fonts/DotGothic16,M_PLUS_1p/DotGothic16/DotGothic16-Regular.ttf' @ warning/annotate.c/RenderType/949.
```

## 加えた変更
* 読み込むフォントファイルの変更

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
