### PR TITLE
fix: 管理画面日付入力フォームを2017年も入力できるように変更

### DIFF
--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Disc do
     f.inputs do
       f.has_many :disc_dates, allow_destroy: true do |t|
         t.input :date_type
-        t.input :date, start_year: 2020
+        t.input :date, start_year: 2020, end_year: 2060
         t.input :remark
       end
     end

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Disc do
     f.inputs do
       f.has_many :disc_dates, allow_destroy: true do |t|
         t.input :date_type
-        t.input :date
+        t.input :date, start_year: 2020
         t.input :remark
       end
     end

--- a/app/admin/links.rb
+++ b/app/admin/links.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Link do
 
     f.inputs do
       f.has_many :link_dates, allow_destroy: true, new_record: true do |t|
-        t.input :date, start_year: 2017
+        t.input :date, start_year: 2017, end_year: 2060
         t.input :date_type
         t.input :remark
       end
@@ -25,7 +25,7 @@ ActiveAdmin.register Link do
 
     f.inputs do
       f.has_many :link_views, allow_destroy: true, new_record: true do |t|
-        t.input :date, start_year: 2017
+        t.input :date, start_year: 2017, end_year: 2060
         t.input :record_type
       end
     end

--- a/app/admin/links.rb
+++ b/app/admin/links.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Link do
 
     f.inputs do
       f.has_many :link_dates, allow_destroy: true, new_record: true do |t|
-        t.input :date
+        t.input :date, start_year: 2017
         t.input :date_type
         t.input :remark
       end
@@ -25,7 +25,7 @@ ActiveAdmin.register Link do
 
     f.inputs do
       f.has_many :link_views, allow_destroy: true, new_record: true do |t|
-        t.input :date
+        t.input :date, start_year: 2017
         t.input :record_type
       end
     end


### PR DESCRIPTION
## 概要
管理画面日付入力フォームを2017年も入力できるように変更

## 加えた変更
* 従来
  [![Image from Gyazo](https://i.gyazo.com/ef53bdad8ece7ae5b34f4862531c1891.png)](https://gyazo.com/ef53bdad8ece7ae5b34f4862531c1891)
  変更後
  [![Image from Gyazo](https://i.gyazo.com/85b9e8080ab1d91023a50377f82ae602.png)](https://gyazo.com/85b9e8080ab1d91023a50377f82ae602)

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
