### PR TITLE
Fix 日付セレクトフォームの修正

### DIFF
--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Disc do
     f.inputs do
       f.has_many :disc_dates, allow_destroy: true do |t|
         t.input :date_type
-        t.input :date, start_year: 2020, end_year: 2060
+        t.input :date, start_year: 2017, end_year: 2060
         t.input :remark
       end
     end


### PR DESCRIPTION
## 概要
2020年からの登録しか許可していないフォームがあったため、修正

## 加えた変更
* 

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
