### PR TITLE
Fix 一時的なサーバー増強

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,6 @@ primary_region = 'nrt'
 
 [[vm]]
   size = 'shared-cpu-1x'
-  memory = '512mb'
+  memory = '2gb'
   cpu_kind = 'shared'
   cpus = 1


### PR DESCRIPTION
## 概要
アクセス集中に備え、メモリを512MBから2GBに増やしました。

## 加えた変更
* 

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
