### PR TITLE
Fix Rubocopに指摘されたアソシエーション修正

### DIFF
--- a/app/models/setlistitem.rb
+++ b/app/models/setlistitem.rb
@@ -1,7 +1,7 @@
 class Setlistitem < ApplicationRecord
   belongs_to :setlist
   has_many :setlistitem_informations, dependent: :destroy
-  has_one :song
+  belongs_to :song, optional: true
 
   validates :is_song, inclusion: { in: [true, false] }
   validates :is_arranged, inclusion: { in: [true, false] }


### PR DESCRIPTION
## 概要
Rubocopに指摘された、アソシエーションを修正しました。

## 加えた変更
* 修正前：`setlistitem`は`has_one: song`である。
  修正後：`setlistitem`は`belongs_to: song`である。

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
