### PR TITLE
Feat イベント検索 オートコンプリート機能 実装

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -44,7 +44,10 @@ class EventsController < ApplicationController
     else
       search_word = params[:q]
     end
-    @events = Event.where(['name LIKE(?) or name_kana_ruby LIKE(?)', "%#{search_word}%", "%#{search_word}%"]).order(date: :desc)
+    @events = Event
+              .where(['name LIKE(?) or name_kana_ruby LIKE(?)', "%#{search_word}%", "%#{search_word}%"])
+              .order(date: :desc)
+              .uniq { |event| event[:name] }
     respond_to do |format|
       format.js
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -39,13 +39,22 @@ class EventsController < ApplicationController
   end
 
   def search
-    @events = Event.where(['name LIKE(?) or name_kana_ruby LIKE(?)', "%#{params[:q]}%", "%#{params[:q]}%"])
+    if params[:q] =~ /\A[ぁ-んー－]+\z/
+      search_word = convert_to_katakana(params[:q])
+    else
+      search_word = params[:q]
+    end
+    @events = Event.where(['name LIKE(?) or name_kana_ruby LIKE(?)', "%#{search_word}%", "%#{search_word}%"])
     respond_to do |format|
       format.js
     end
   end
 
   private
+
+  def convert_to_katakana(str)
+    str.tr('ぁ-ん', 'ァ-ン')
+  end
 
   def prepare_meta_tags(event)
     event_date = event.date.strftime('%Y/%m/%d')

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -44,7 +44,7 @@ class EventsController < ApplicationController
     else
       search_word = params[:q]
     end
-    @events = Event.where(['name LIKE(?) or name_kana_ruby LIKE(?)', "%#{search_word}%", "%#{search_word}%"])
+    @events = Event.where(['name LIKE(?) or name_kana_ruby LIKE(?)', "%#{search_word}%", "%#{search_word}%"]).order(date: :desc)
     respond_to do |format|
       format.js
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -39,11 +39,11 @@ class EventsController < ApplicationController
   end
 
   def search
-    if params[:q] =~ /\A[ぁ-んー－]+\z/
-      search_word = convert_to_katakana(params[:q])
-    else
-      search_word = params[:q]
-    end
+    search_word = if params[:q] =~ /\A[ぁ-んー－]+\z/
+                    convert_to_katakana(params[:q])
+                  else
+                    params[:q]
+                  end
     @events = Event
               .where(['name LIKE(?) or name_kana_ruby LIKE(?)', "%#{search_word}%", "%#{search_word}%"])
               .order(date: :desc)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -38,6 +38,13 @@ class EventsController < ApplicationController
     @event = Event.includes(visual_image_attachment: :blob).find(params[:id])
   end
 
+  def search
+    @events = Event.where(['name LIKE(?) or name_kana_ruby LIKE(?)', "%#{params[:q]}%", "%#{params[:q]}%"])
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def prepare_meta_tags(event)

--- a/app/views/events/modals/_search_form_modal.html.erb
+++ b/app/views/events/modals/_search_form_modal.html.erb
@@ -8,7 +8,10 @@
 
         <div class="mb-3">
           <%= f.label "イベント名" %>
-          <%= f.search_field :name_or_name_kana_ruby_cont, placeholder: 'イベント名を入力', type: "text", class: "input input-bordered w-full border-neutral-content bg-transparent" %>
+          <div data-controller="autocomplete" data-autocomplete-url-value="/events/search" role="combobox", class="mb-3 w-full">
+            <%= f.search_field :name_or_name_kana_ruby_cont, placeholder: 'イベント名を入力', type: "text", class: "input input-bordered w-full border-neutral-content bg-transparent", data: { autocomplete_target: 'input' } %>
+            <ul class="list-group bg-white w-full md:text-sm" data-autocomplete-target="results"></ul>
+          </div>
         </div>
 
         <div class="mb-3">

--- a/app/views/events/search.html.erb
+++ b/app/views/events/search.html.erb
@@ -1,0 +1,5 @@
+<% @events.each do |event| %>
+  <li class="w-full flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= event.name %>" data-autocomplete-label="<%= event.name %>">
+    <%= event.name.truncate(30) %>
+  </li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get 'member/:id/image' => "members#image"
   get 'gear/:id/image' => "members#gear_image"
   get 'songs/search' => "songs#search"
+  get 'events/search' => "events#search"
   get 'images/ogp.png', to: 'images#ogp', as: 'images_ogp'
 
   # （ここから）Twitter認証以外を認めないようにルーティングを設定しようとした痕跡


### PR DESCRIPTION
## 概要
イベント検索フォームにオートコンプリート機能を実装しました。

## 加えた変更
* 変更後
  [![Image from Gyazo](https://i.gyazo.com/d9e85e44d7781cb1612cb475cb25a715.gif)](https://gyazo.com/d9e85e44d7781cb1612cb475cb25a715)
  * 候補は開催日昇順で表示され、最新のものほど上位に表示される
  * ツアーなど同イベント名が複数ある場合はまとめて表示

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #450 