### PR TITLE
Feat YouTubeAPI送信等のジョブの定期実行設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client imagemagick && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client imagemagick cron && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN apt-get update -qq \
 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
 && wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim imagemagick
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim imagemagick cron
 RUN apt-get update && apt-get install -y libvips42
 RUN mkdir /myapp
 WORKDIR /myapp

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'omniauth-twitter'
 gem 'pry-byebug'
 gem 'rails-i18n'
 gem 'ransack'
+gem 'whenever', require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
@@ -551,6 +552,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.1)
@@ -608,6 +611,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  whenever
 
 BUNDLED WITH
    2.5.20

--- a/app/jobs/process_link_view_records_job.rb
+++ b/app/jobs/process_link_view_records_job.rb
@@ -1,0 +1,8 @@
+class ProcessLinkViewRecordsJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    CreateLinkViewRecordJob.perform_now
+    FetchYoutubeRecordJob.perform_now
+  end
+end

--- a/app/jobs/process_link_view_records_job.rb
+++ b/app/jobs/process_link_view_records_job.rb
@@ -1,7 +1,7 @@
 class ProcessLinkViewRecordsJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
+  def perform(*_args)
     CreateLinkViewRecordJob.perform_now
     FetchYoutubeRecordJob.perform_now
   end

--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,8 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+      MYAPP_DATABASE_PASSWORD: ${MYAPP_DATABASE_PASSWORD}
     ports:
       - "3000:3000"
     depends_on:

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: db
   username: postgres
-  password: password
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "password") %>
 
 
 development:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,7 +5,7 @@ set :environment, rails_env
 set :output, "#{Rails.root}/log/cron.log"
 ENV.each { |k, v| env(k, v) }
 
-every 1.minute do
+every 6.hours do
   rake "job:process_link_view_records"
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,20 +1,11 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
+require File.expand_path(File.dirname(__FILE__) + '/environment')
 
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
+rails_env = ENV['RAILS_ENV'] || :development
+set :environment, rails_env
+set :output, "#{Rails.root}/log/cron.log"
+
+every 1.minute do
+  rake "job:process_link_view_records"
+end
 
 # Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,6 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/environment')
 rails_env = ENV['RAILS_ENV'] || :development
 set :environment, rails_env
 set :output, "#{Rails.root}/log/cron.log"
+ENV.each { |k, v| env(k, v) }
 
 every 1.minute do
   rake "job:process_link_view_records"

--- a/lib/tasks/job.rake
+++ b/lib/tasks/job.rake
@@ -8,4 +8,9 @@ namespace :job do
   task create_link_view_record: :environment do
     CreateLinkViewRecordJob.perform_now
   end
+
+  desc 'YouTubeAPIリクエストでlink_view_recordを作成し、link_viewを作成する'
+  task process_link_view_records: :environment do
+    ProcessLinkViewRecordsJob.perform_now
+  end
 end

--- a/spec/jobs/create_link_view_record_job_spec.rb
+++ b/spec/jobs/create_link_view_record_job_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe CreateLinkViewRecordJob, type: :job do
   describe '正常系: メソッド' do
     context '2つのLinkViewCountレコードが存在する時' do
       it '100万以上の桁が同じであれば、LinkViewレコードが作成されない' do
-        link = create(:link)
+        link = create(:link_youtube)
         create(:previous_link_view_count, link: link)
         create(:now_same_million_link_view_count, link: link)
         expect { CreateLinkViewRecordJob.perform_now }.to change(LinkView, :count).by(0)
       end
       it '100万以上の桁が異なれば、LinkViewレコードが作成される' do
-        link = create(:link)
+        link = create(:link_youtube)
         create(:previous_link_view_count, link: link)
         create(:next_million_link_view_count, link: link)
         expect { CreateLinkViewRecordJob.perform_now }.to change(LinkView, :count).by(1)

--- a/spec/jobs/process_link_view_records_job_spec.rb
+++ b/spec/jobs/process_link_view_records_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProcessLinkViewRecordsJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
`CreateLinkViewRecordJob`と`FetchYoutubeRecordJob`を、6時間おきに自動実行するように設定しました。

## 加えた変更
* 定期実行用 関連gemセットアップ
* `CreateLinkViewRecordJob`と`FetchYoutubeRecordJob`をまとめて実行するための`ProcessLinkViewRecordsJob`を設定
* `ProcessLinkViewRecordsJob`の定期実行を設定

## 加えなかった変更
* ログが`log/crontab.log`にうまく反映されなかったため、本番環境の挙動次第では要対応
* 本番環境でも、cronを使用するために`bundle exec whenever --update-crontab`と`service cron restart`は実行が必要

## 影響範囲

## 関連Issue
* close #460 