### PR TITLE
Fix Discの管理ページ編集

### DIFF
--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -2,8 +2,9 @@ ActiveAdmin.register Disc do
   remove_filter :links, :disc_dates
   permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type,
                 disc_versions_attributes: [:id, :version, :price, :_destroy,
-                                           disc_contents_attributes: [:id, :content_type, :event_id, :_destroy,
-                                                                     disc_items_attributes: [:id, :position, :title, :song_id, :is_arranged, :_destroy]]],
+                                           { disc_contents_attributes: [:id, :content_type, :event_id, :_destroy,
+                                                                        { disc_items_attributes:
+                                                                        %i[id position title song_id is_arranged _destroy] }] }],
                 link_contents_attributes: [:id, :link_id, :_destroy],
                 disc_dates_attributes: [:id, :date_type, :date, :remark, :_destroy]
   menu parent: 'Disc'

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -31,6 +31,11 @@ ActiveAdmin.register Disc do
         t.has_many :disc_contents, allow_destroy: true do |c|
           c.input :content_type
           c.input :event_id, as: :select, collection: Event.order(date: :desc).map { |x| [x.name, x.id] }
+          c.has_many :disc_items, allow_destroy: true do |i|
+            i.input :position
+            i.input :title
+            i.input :song_id, as: :select, collection: Song.order(name: :asc).map { |x| [x.name, x.id] }
+          end
         end
       end
     end

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -28,6 +28,10 @@ ActiveAdmin.register Disc do
       f.has_many :disc_versions, allow_destroy: true do |t|
         t.input :version
         t.input :price
+        t.has_many :disc_contents, allow_destroy: true do |c|
+          c.input :content_type
+          c.input :event_id, as: :select, collection: Event.order(date: :desc).map { |x| [x.name, x.id] }
+        end
       end
     end
 

--- a/app/admin/discs.rb
+++ b/app/admin/discs.rb
@@ -1,7 +1,9 @@
 ActiveAdmin.register Disc do
   remove_filter :links, :disc_dates
   permit_params :title, :title_ruby, :announcement_date, :release_date, :production_type,
-                disc_versions_attributes: [:id, :version, :price, :_destroy],
+                disc_versions_attributes: [:id, :version, :price, :_destroy,
+                                           disc_contents_attributes: [:id, :content_type, :event_id, :_destroy,
+                                                                     disc_items_attributes: [:id, :position, :title, :song_id, :is_arranged, :_destroy]]],
                 link_contents_attributes: [:id, :link_id, :_destroy],
                 disc_dates_attributes: [:id, :date_type, :date, :remark, :_destroy]
   menu parent: 'Disc'
@@ -35,6 +37,7 @@ ActiveAdmin.register Disc do
             i.input :position
             i.input :title
             i.input :song_id, as: :select, collection: Song.order(name: :asc).map { |x| [x.name, x.id] }
+            i.input :is_arranged, as: :boolean
           end
         end
       end


### PR DESCRIPTION
## 概要
/admin/discs/newページでDisc情報を一括で編集できるようにフォームを修正しました。

## 加えた変更
* 従来：バージョン情報しか追加できない。
  [![Image from Gyazo](https://i.gyazo.com/f72764f6965e1f9b4e7eac273095f4e1.png)](https://gyazo.com/f72764f6965e1f9b4e7eac273095f4e1)
* 修正後：各バージョンの収録コンテンツ・収録楽曲フォームから登録可能。
  [![Image from Gyazo](https://i.gyazo.com/7775d1553fd806d61318ac0e45b66fb6.png)](https://gyazo.com/7775d1553fd806d61318ac0e45b66fb6)

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #370 
