### PR TITLE
Feat 管理者ページ テスト

### DIFF
--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -167,7 +167,7 @@ ActiveAdmin.setup do |config|
   # You can add before, after and around filters to all of your
   # Active Admin resources and pages from here.
   #
-  # config.before_action :do_something_awesome
+  config.skip_before_action :authenticate_user!
 
   # == Attribute Filters
   #

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  numbers = ('0'..'9').to_a
+
+  factory :admin_user do
+    sequence(:email) { |n| "admin_#{numbers[n]}@example.com" }
+    sequence(:password) { |n| "password_#{numbers[n]}" }
+    sequence(:password_confirmation) { |n| "password_#{numbers[n]}" }
+  end
+end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   numbers = ('0'..'9').to_a
 
   factory :admin_user do
-    sequence(:email) { |n| "admin_#{numbers[n]}@example.com" }
-    sequence(:password) { |n| "password_#{numbers[n]}" }
-    sequence(:password_confirmation) { |n| "password_#{numbers[n]}" }
+    sequence(:email) { |n| "admin_#{numbers[n % numbers.length]}@example.com" }
+    sequence(:password) { |n| "password_#{numbers[n % numbers.length]}" }
+    sequence(:password_confirmation) { |n| "password_#{numbers[n % numbers.length]}" }
   end
 end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe AdminUser, type: :model do
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_presence_of :password }
 
-    context "passwordとpassword_confirmationが一致しない場合" do
-      it "エラーが発生する" do
-        admin_user.password_confirmation = "different_password"
+    context 'passwordとpassword_confirmationが一致しない場合' do
+      it 'エラーが発生する' do
+        admin_user.password_confirmation = 'different_password'
         expect(admin_user).not_to be_valid
-        expect(admin_user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
+        expect(admin_user.errors[:password_confirmation]).to include('とPasswordの入力が一致しません')
       end
     end
   end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe AdminUser, type: :model do
+  let(:admin_user) { build(:admin_user) }
+
+  describe '正常系: バリデーション' do
+    context '全ての属性が正しい場合' do
+      it 'エラーなくAdminUserが作成される' do
+        expect(admin_user).to be_valid
+        expect(admin_user.errors).to be_empty
+      end
+    end
+  end
+
+  describe '異常系: バリデーション' do
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_presence_of :password }
+
+    context "passwordとpassword_confirmationが一致しない場合" do
+      it "エラーが発生する" do
+        admin_user.password_confirmation = "different_password"
+        expect(admin_user).not_to be_valid
+        expect(admin_user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
+      end
+    end
+  end
+end

--- a/spec/system/admin_users_spec.rb
+++ b/spec/system/admin_users_spec.rb
@@ -1,36 +1,36 @@
 require 'rails_helper'
 
-RSpec.describe "AdminUsers", type: :system do
+RSpec.describe 'AdminUsers', type: :system do
   before do
     driven_by(:rack_test)
   end
 
   let(:admin_user) { create(:admin_user) }
 
-  describe "管理者として未ログイン時" do
-    context "管理者ログインページにアクセスした時" do
-      it "ログインページが表示される" do
+  describe '管理者として未ログイン時' do
+    context '管理者ログインページにアクセスした時' do
+      it 'ログインページが表示される' do
         visit new_admin_user_session_path
         expect(page).to have_current_path(new_admin_user_session_path)
       end
 
-      it "管理者としてログインできる" do
+      it '管理者としてログインできる' do
         visit new_admin_user_session_path
-        fill_in "admin_user_email", with: admin_user.email
-        fill_in "admin_user_password", with: admin_user.password
-        click_button "ログイン"
+        fill_in 'admin_user_email', with: admin_user.email
+        fill_in 'admin_user_password', with: admin_user.password
+        click_button 'ログイン'
         expect(page).to have_current_path(admin_root_path)
       end
     end
   end
 
-  describe "管理者としてログイン時" do
+  describe '管理者としてログイン時' do
     before do
       sign_in admin_user
     end
 
-    context "管理者ログインページにアクセスした時" do
-      it "管理者トップページにリダイレクトされる" do
+    context '管理者ログインページにアクセスした時' do
+      it '管理者トップページにリダイレクトされる' do
         sign_in admin_user
         visit new_admin_user_session_path
         expect(page).to have_current_path(admin_root_path)

--- a/spec/system/admin_users_spec.rb
+++ b/spec/system/admin_users_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe "AdminUsers", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  let(:admin_user) { create(:admin_user) }
+
+  describe "管理者として未ログイン時" do
+    context "管理者ログインページにアクセスした時" do
+      it "ログインページが表示される" do
+        visit new_admin_user_session_path
+        expect(page).to have_current_path(new_admin_user_session_path)
+      end
+
+      it "管理者としてログインできる" do
+        visit new_admin_user_session_path
+        fill_in "admin_user_email", with: admin_user.email
+        fill_in "admin_user_password", with: admin_user.password
+        click_button "ログイン"
+        expect(page).to have_current_path(admin_root_path)
+      end
+    end
+  end
+
+  describe "管理者としてログイン時" do
+    before do
+      sign_in admin_user
+    end
+
+    context "管理者ログインページにアクセスした時" do
+      it "管理者トップページにリダイレクトされる" do
+        sign_in admin_user
+        visit new_admin_user_session_path
+        expect(page).to have_current_path(admin_root_path)
+      end
+    end
+  end
+end

--- a/spec/system/admin_users_spec.rb
+++ b/spec/system/admin_users_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'AdminUsers', type: :system do
 
     context '管理者ログインページにアクセスした時' do
       it '管理者トップページにリダイレクトされる' do
-        sign_in admin_user
         visit new_admin_user_session_path
         expect(page).to have_current_path(admin_root_path)
       end


### PR DESCRIPTION
## 概要
管理者ページに関するテストを作成しました。

## 加えた変更
* 一般ユーザーとして未ログインの状態でも管理者ページにアクセス可能に変更
* `admin_user`のFactoryBot・モデルスペック・システムスペック作成

## 加えなかった変更
* 

## 影響範囲

## 関連Issue

