### PR TITLE
Feat 不要なlink_view_countレコードの削除

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.1)
       racc
     builder (3.3.0)
     bullet (8.0.0)

--- a/app/jobs/cleanup_past_view_records_job.rb
+++ b/app/jobs/cleanup_past_view_records_job.rb
@@ -1,0 +1,18 @@
+class CleanupPastViewRecordsJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    @links = Link.all
+    @links.each do |link|
+      @link_view_counts = link.link_view_counts
+      unless @link_view_counts.length > 2
+        return
+      end
+      @records_for_cleanup = @link_view_counts[0..-3]
+      @records_for_cleanup.each do |record|
+        @link_view_count = LinkViewCount.find(record.id)
+        @link_view_count.destroy
+      end
+    end
+  end
+end

--- a/app/jobs/cleanup_past_view_records_job.rb
+++ b/app/jobs/cleanup_past_view_records_job.rb
@@ -1,15 +1,15 @@
 class CleanupPastViewRecordsJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
+  def perform(*_args)
     @links = Link.where(platform: 0)
     @links.each do |link|
       @link_view_counts = link.link_view_counts.order(created_at: :asc)
       if @link_view_counts.length < 3
-        p "link_view_countsの数が2以下のため、削除しません"
+        Rails.logger.debug 'link_view_countsの数が2以下のため、削除しません'
         next
       end
-      p "link_view_countsの数が2以上のため、削除します"
+      Rails.logger.debug 'link_view_countsの数が2以上のため、削除します'
       @records_for_cleanup = @link_view_counts[0..-3]
       @records_for_cleanup.each do |record|
         @link_view_count = LinkViewCount.find(record.id)

--- a/app/jobs/cleanup_past_view_records_job.rb
+++ b/app/jobs/cleanup_past_view_records_job.rb
@@ -2,12 +2,14 @@ class CleanupPastViewRecordsJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
-    @links = Link.all
+    @links = Link.where(platform: 0)
     @links.each do |link|
-      @link_view_counts = link.link_view_counts
-      unless @link_view_counts.length > 2
-        return
+      @link_view_counts = link.link_view_counts.order(created_at: :asc)
+      if @link_view_counts.length < 3
+        p "link_view_countsの数が2以下のため、削除しません"
+        next
       end
+      p "link_view_countsの数が2以上のため、削除します"
       @records_for_cleanup = @link_view_counts[0..-3]
       @records_for_cleanup.each do |record|
         @link_view_count = LinkViewCount.find(record.id)

--- a/app/jobs/process_link_view_records_job.rb
+++ b/app/jobs/process_link_view_records_job.rb
@@ -2,6 +2,7 @@ class ProcessLinkViewRecordsJob < ApplicationJob
   queue_as :default
 
   def perform(*_args)
+    CleanupPastViewRecordsJob.perform_now
     CreateLinkViewRecordJob.perform_now
     FetchYoutubeRecordJob.perform_now
   end

--- a/spec/jobs/cleanup_past_view_records_job_spec.rb
+++ b/spec/jobs/cleanup_past_view_records_job_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe CleanupPastViewRecordsJob, type: :job do
+  let(:link) { create(:link) }
+  let(:link_view_count1) { create(:link_view_count, link: link, view_count: 0, created_at: 20200101) }
+  let(:link_view_count2) { create(:link_view_count, link: link, view_count: 10000000, created_at: 20200102) }
+  let(:link_view_count3) { create(:link_view_count, link: link, view_count: 20000000, created_at: 20200103) }
+  let(:link_view_count4) { create(:link_view_count, link: link, view_count: 30000000, created_at: 20200104) }
+
+  describe '#perform' do
+    context 'when there are more than 2 link_view_counts' do
+      before do
+        link_view_count1
+        link_view_count2
+        link_view_count3
+        link_view_count4
+      end
+
+      it 'deletes the oldest records' do
+        expect { CleanupPastViewRecordsJob.perform_now }.to change(LinkViewCount, :count).by(-2)
+      end
+
+      it 'does not delete the most recent records' do
+        CleanupPastViewRecordsJob.perform_now
+        expect(LinkViewCount.where(id: [link_view_count3.id, link_view_count4.id])).to exist
+      end
+    end
+
+    context 'when there are 2 or fewer link_view_counts' do
+      before do
+        link_view_count1
+        link_view_count2
+      end
+
+      it 'does not delete any records' do
+        expect { CleanupPastViewRecordsJob.perform_now }.not_to change(LinkViewCount, :count)
+      end
+    end
+  end
+end

--- a/spec/jobs/cleanup_past_view_records_job_spec.rb
+++ b/spec/jobs/cleanup_past_view_records_job_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe CleanupPastViewRecordsJob, type: :job do
   let(:link) { create(:link) }
-  let(:link_view_count1) { create(:link_view_count, link: link, view_count: 0, created_at: 20200101) }
-  let(:link_view_count2) { create(:link_view_count, link: link, view_count: 10000000, created_at: 20200102) }
-  let(:link_view_count3) { create(:link_view_count, link: link, view_count: 20000000, created_at: 20200103) }
-  let(:link_view_count4) { create(:link_view_count, link: link, view_count: 30000000, created_at: 20200104) }
+  let(:link_view_count1) { create(:link_view_count, link: link, view_count: 0, created_at: 20_200_101) }
+  let(:link_view_count2) { create(:link_view_count, link: link, view_count: 10_000_000, created_at: 20_200_102) }
+  let(:link_view_count3) { create(:link_view_count, link: link, view_count: 20_000_000, created_at: 20_200_103) }
+  let(:link_view_count4) { create(:link_view_count, link: link, view_count: 30_000_000, created_at: 20_200_104) }
 
   describe '#perform' do
     context 'when there are more than 2 link_view_counts' do


### PR DESCRIPTION
## 概要
link_view_countレコードが溜まっていってしまうため、YouTubeAPI送信ジョブと同時に不要なレコードを削除する処理を行います。

## 加えた変更
* レコード削除ジョブの作成
* YouTubeAPI送信ジョブと同時にレコード削除ジョブを実行

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #494 
