### PR TITLE
Fix: crontabの実行を30分おきに変更

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,2 +1,2 @@
 0 0,6,12,18 * * * bundle exec rake job:process_link_view_records
-*/1 * * * * echo "cron is running!"
+*/30 * * * * echo "cron is running!"


### PR DESCRIPTION
## 概要
crontabの実行を30分おきに変更（1分おきだと過度に費用がかかるため）

## 加えた変更
* crontabの実行を30分おきに変更

## 加えなかった変更
* 

## 影響範囲

## 関連Issue
* close #
